### PR TITLE
fix: derive runtime group from entitlements

### DIFF
--- a/internal/admin/model/cache.go
+++ b/internal/admin/model/cache.go
@@ -53,17 +53,17 @@ func CacheGetTokenByKey(key string) (*Token, error) {
 
 func CacheGetUserGroup(id string) (group string, err error) {
 	if !common.RedisEnabled {
-		return GetUserGroup(id)
+		return GetUserEffectiveGroup(id)
 	}
-	group, err = common.RedisGet(fmt.Sprintf("user_group:%s", id))
+	group, err = common.RedisGet(fmt.Sprintf("user_effective_group:%s", id))
 	if err != nil {
-		group, err = GetUserGroup(id)
+		group, err = GetUserEffectiveGroup(id)
 		if err != nil {
 			return "", err
 		}
-		err = common.RedisSet(fmt.Sprintf("user_group:%s", id), group, time.Duration(UserId2GroupCacheSeconds)*time.Second)
+		err = common.RedisSet(fmt.Sprintf("user_effective_group:%s", id), group, time.Duration(UserId2GroupCacheSeconds)*time.Second)
 		if err != nil {
-			logger.SysError("Redis set user group error: " + err.Error())
+			logger.SysError("Redis set user effective group error: " + err.Error())
 		}
 	}
 	return group, err

--- a/internal/admin/model/group_model_config.go
+++ b/internal/admin/model/group_model_config.go
@@ -317,7 +317,7 @@ func replaceGroupModelConfigsWithDB(db *gorm.DB, groupID string, channelIDs []st
 		}
 		seenKeys[key] = struct{}{}
 		provider := NormalizeGroupModelRouteProvider(selectedCatalogs[item.ChannelId].ResolveProvider(item, upstreamModel))
-		if existingProvider, ok := groupModelProviders[item.Model]; ok && existingProvider != provider {
+		if existingProvider, ok := groupModelProviders[item.Model]; ok && existingProvider != "" && provider != "" && existingProvider != provider {
 			return fmt.Errorf("同一分组模型仅允许一个供应商: %s (%s / %s)", item.Model, existingProvider, provider)
 		}
 		if _, ok := groupModelProviders[item.Model]; !ok {
@@ -328,6 +328,14 @@ func replaceGroupModelConfigsWithDB(db *gorm.DB, groupID string, channelIDs []st
 				Provider: provider,
 				Enabled:  resolveGroupModelConfigEnabled(item),
 			})
+		} else if groupModelProviders[item.Model] == "" && provider != "" {
+			groupModelProviders[item.Model] = provider
+			for index := range groupModels {
+				if groupModels[index].Model == item.Model {
+					groupModels[index].Provider = provider
+					break
+				}
+			}
 		}
 	}
 	if err := replaceGroupModelsWithDB(db, groupID, groupModels); err != nil {

--- a/internal/admin/model/user_effective_group.go
+++ b/internal/admin/model/user_effective_group.go
@@ -1,0 +1,122 @@
+package model
+
+import (
+	"database/sql"
+	"fmt"
+	"strings"
+
+	"github.com/yeying-community/router/common/helper"
+	"gorm.io/gorm"
+)
+
+func scanSingleGroupID(row *sql.Row) (string, bool, error) {
+	groupID := ""
+	if err := row.Scan(&groupID); err != nil {
+		if err == sql.ErrNoRows {
+			return "", false, nil
+		}
+		return "", false, err
+	}
+	return strings.TrimSpace(groupID), strings.TrimSpace(groupID) != "", nil
+}
+
+func getActivePackageEntitlementGroupWithDB(db *gorm.DB, userID string, now int64) (string, bool, error) {
+	if err := syncUserPackageSubscriptionsWithDB(db, userID, now); err != nil {
+		return "", false, err
+	}
+	return scanSingleGroupID(db.Raw(`
+		SELECT s.group_id
+		FROM user_package_subscriptions s
+		JOIN groups g ON g.id = s.group_id AND g.enabled = TRUE
+		WHERE s.user_id = ?
+		  AND s.status = ?
+		  AND s.started_at <= ?
+		  AND (s.expires_at = 0 OR s.expires_at > ?)
+		  AND COALESCE(TRIM(s.group_id), '') <> ''
+		ORDER BY s.updated_at DESC, s.started_at DESC, s.id DESC
+		LIMIT 1
+	`, userID, UserPackageSubscriptionStatusActive, now, now).Row())
+}
+
+func getActiveTopupEntitlementGroupWithDB(db *gorm.DB, userID string, now int64) (string, bool, error) {
+	return scanSingleGroupID(db.Raw(`
+		SELECT p.group_id
+		FROM user_balance_lots l
+		JOIN topup_orders o ON o.id = l.source_id
+		JOIN topup_plans p ON p.id = o.topup_plan_id
+		JOIN groups g ON g.id = p.group_id AND g.enabled = TRUE
+		WHERE l.user_id = ?
+		  AND l.source_type = ?
+		  AND l.status = ?
+		  AND l.remaining_yyc > 0
+		  AND (l.expires_at = 0 OR l.expires_at > ?)
+		  AND COALESCE(TRIM(p.group_id), '') <> ''
+		ORDER BY l.granted_at DESC, l.created_at DESC, l.id DESC
+		LIMIT 1
+	`, userID, UserBalanceLotSourceTopup, UserBalanceLotStatusActive, now).Row())
+}
+
+func getActiveRedemptionEntitlementGroupWithDB(db *gorm.DB, userID string, now int64) (string, bool, error) {
+	return scanSingleGroupID(db.Raw(`
+		SELECT r.group_id
+		FROM user_balance_lots l
+		JOIN redemptions r ON r.id = l.source_id
+		JOIN groups g ON g.id = r.group_id AND g.enabled = TRUE
+		WHERE l.user_id = ?
+		  AND l.source_type = ?
+		  AND l.status = ?
+		  AND l.remaining_yyc > 0
+		  AND (l.expires_at = 0 OR l.expires_at > ?)
+		  AND COALESCE(TRIM(r.group_id), '') <> ''
+		ORDER BY l.granted_at DESC, l.created_at DESC, l.id DESC
+		LIMIT 1
+	`, userID, UserBalanceLotSourceRedeem, UserBalanceLotStatusActive, now).Row())
+}
+
+func getLegacyUserGroupWithDB(db *gorm.DB, userID string) (string, bool, error) {
+	return scanSingleGroupID(db.Raw(`
+		SELECT u."group"
+		FROM users u
+		JOIN groups g ON g.id = u."group" AND g.enabled = TRUE
+		WHERE u.id = ?
+		  AND COALESCE(TRIM(u."group"), '') <> ''
+		LIMIT 1
+	`, userID).Row())
+}
+
+func getUserEffectiveGroupWithDB(db *gorm.DB, userID string) (string, error) {
+	if db == nil {
+		return "", fmt.Errorf("database handle is nil")
+	}
+	normalizedUserID := strings.TrimSpace(userID)
+	if normalizedUserID == "" {
+		return "", nil
+	}
+	now := helper.GetTimestamp()
+	resolvers := []func(*gorm.DB, string, int64) (string, bool, error){
+		getActivePackageEntitlementGroupWithDB,
+		getActiveTopupEntitlementGroupWithDB,
+		getActiveRedemptionEntitlementGroupWithDB,
+	}
+	for _, resolve := range resolvers {
+		groupID, ok, err := resolve(db, normalizedUserID, now)
+		if err != nil {
+			return "", err
+		}
+		if ok {
+			return groupID, nil
+		}
+	}
+	groupID, ok, err := getLegacyUserGroupWithDB(db, normalizedUserID)
+	if err != nil {
+		return "", err
+	}
+	if ok {
+		return groupID, nil
+	}
+	return "", nil
+}
+
+func GetUserEffectiveGroup(userID string) (string, error) {
+	return getUserEffectiveGroupWithDB(DB, userID)
+}


### PR DESCRIPTION
## Summary
- derive runtime group from active package, top-up, or redemption entitlements instead of relying only on users.group
- ignore empty provider values when validating group model provider conflicts and backfill the first non-empty provider

## Tests
- go test ./internal/admin/model ./internal/admin/controller ./internal/transport/http/middleware
