### PR TITLE
fix: honor group route priorities at runtime

### DIFF
--- a/internal/admin/model/ability_selection_test.go
+++ b/internal/admin/model/ability_selection_test.go
@@ -123,3 +123,26 @@ func TestSelectRandomSatisfiedChannelReturnsNilWhenAllTiersExhausted(t *testing.
 		t.Fatalf("unexpected remaining candidates: got %d want %d", stats.RemainingCandidates, 0)
 	}
 }
+
+func TestSelectRandomSatisfiedChannelUsesRoutePriorityOverride(t *testing.T) {
+	basePriority := int64(0)
+	channels := []*Channel{
+		CloneChannelWithPriority(&Channel{Id: "channel-a", Priority: &basePriority}, 1),
+		CloneChannelWithPriority(&Channel{Id: "channel-b", Priority: &basePriority}, 1),
+		CloneChannelWithPriority(&Channel{Id: "channel-c", Priority: &basePriority}, 0),
+	}
+
+	got, stats := SelectRandomSatisfiedChannelWithStats(channels, false, nil)
+	if got == nil {
+		t.Fatalf("expected channel, got nil")
+	}
+	if got.Id != "channel-a" && got.Id != "channel-b" {
+		t.Fatalf("unexpected channel id: got %q want tier-1 candidate", got.Id)
+	}
+	if stats.SelectedPriority != 1 {
+		t.Fatalf("selected priority = %d, want 1", stats.SelectedPriority)
+	}
+	if stats.SelectedTierCandidates != 2 {
+		t.Fatalf("selected tier candidates = %d, want 2", stats.SelectedTierCandidates)
+	}
+}

--- a/internal/admin/model/cache.go
+++ b/internal/admin/model/cache.go
@@ -235,7 +235,10 @@ func InitChannelCache() {
 		if _, ok := newGroup2model2channel2upstream[groupName][modelName]; !ok {
 			newGroup2model2channel2upstream[groupName][modelName] = make(map[string]string)
 		}
-		newGroup2model2channels[groupName][modelName] = append(newGroup2model2channels[groupName][modelName], channel)
+		newGroup2model2channels[groupName][modelName] = append(
+			newGroup2model2channels[groupName][modelName],
+			CloneChannelWithPriority(channel, route.GetPriority()),
+		)
 		newGroup2model2channel2upstream[groupName][modelName][channelID] = NormalizeGroupModelRouteUpstreamModel(modelName, route.UpstreamModel)
 	}
 
@@ -243,7 +246,12 @@ func InitChannelCache() {
 	for group, model2channels := range newGroup2model2channels {
 		for model, channels := range model2channels {
 			sort.Slice(channels, func(i, j int) bool {
-				return channels[i].GetPriority() > channels[j].GetPriority()
+				leftPriority := channels[i].GetPriority()
+				rightPriority := channels[j].GetPriority()
+				if leftPriority != rightPriority {
+					return leftPriority > rightPriority
+				}
+				return strings.TrimSpace(channels[i].Id) < strings.TrimSpace(channels[j].Id)
 			})
 			newGroup2model2channels[group][model] = channels
 		}

--- a/internal/admin/model/channel.go
+++ b/internal/admin/model/channel.go
@@ -178,6 +178,16 @@ func (channel *Channel) GetPriority() int64 {
 	return *channel.Priority
 }
 
+func CloneChannelWithPriority(channel *Channel, priority int64) *Channel {
+	if channel == nil {
+		return nil
+	}
+	cloned := *channel
+	clonedPriority := priority
+	cloned.Priority = &clonedPriority
+	return &cloned
+}
+
 func (channel *Channel) GetBaseURL() string {
 	if channel.BaseURL == nil {
 		return ""

--- a/internal/admin/model/group_model_route.go
+++ b/internal/admin/model/group_model_route.go
@@ -17,6 +17,13 @@ type GroupModelRoute struct {
 	Priority      *int64 `json:"priority" gorm:"bigint;default:0;index"`
 }
 
+func (route GroupModelRoute) GetPriority() int64 {
+	if route.Priority == nil {
+		return 0
+	}
+	return *route.Priority
+}
+
 const (
 	GroupModelRoutesTableName = "group_model_routes"
 )

--- a/internal/admin/model/group_model_route_test.go
+++ b/internal/admin/model/group_model_route_test.go
@@ -40,3 +40,28 @@ func TestNormalizeGroupModelRouteRowsPreserveOrder_DeduplicatesByPrimaryKey(t *t
 		t.Fatalf("unexpected fallback upstream model: %q", got[1].UpstreamModel)
 	}
 }
+
+func TestCloneChannelWithPriorityDoesNotMutateOriginal(t *testing.T) {
+	originalPriority := int64(0)
+	channel := &Channel{
+		Id:       "channel-1",
+		Priority: &originalPriority,
+	}
+
+	cloned := CloneChannelWithPriority(channel, 3)
+	if cloned == nil {
+		t.Fatalf("expected cloned channel, got nil")
+	}
+	if cloned == channel {
+		t.Fatalf("expected cloned channel to be a different pointer")
+	}
+	if channel.GetPriority() != 0 {
+		t.Fatalf("original priority = %d, want 0", channel.GetPriority())
+	}
+	if cloned.GetPriority() != 3 {
+		t.Fatalf("cloned priority = %d, want 3", cloned.GetPriority())
+	}
+	if cloned.Priority == channel.Priority {
+		t.Fatalf("expected cloned priority pointer to be independent")
+	}
+}

--- a/internal/admin/repository/groupmodelroute/repository.go
+++ b/internal/admin/repository/groupmodelroute/repository.go
@@ -74,10 +74,11 @@ func ListSatisfiedChannels(group string, modelName string) ([]*model.Channel, er
 		}
 		channelByID[strings.TrimSpace(channel.Id)] = channel
 	}
-	result := make([]*model.Channel, 0, len(channelIDs))
-	for _, channelID := range channelIDs {
+	result := make([]*model.Channel, 0, len(routeRows))
+	for _, route := range routeRows {
+		channelID := strings.TrimSpace(route.ChannelId)
 		if channel := channelByID[channelID]; channel != nil {
-			result = append(result, channel)
+			result = append(result, model.CloneChannelWithPriority(channel, route.GetPriority()))
 		}
 	}
 	return result, nil
@@ -243,6 +244,8 @@ func GetTopChannelByModel(group string, modelName string) (*model.Channel, error
 	if err := model.HydrateChannelWithModels(model.DB, &channel); err != nil {
 		return nil, err
 	}
+	priority := route.GetPriority()
+	channel.Priority = &priority
 	return &channel, nil
 }
 


### PR DESCRIPTION
## Summary
- use group model route priority during runtime channel selection
- keep cached and repository-loaded channels aligned with route priority
- add tests covering cloned priority override and ability selection

## Verification
- go test ./internal/admin/model ./internal/admin/controller ./internal/transport/http/middleware
- go build -o /tmp/router ./cmd/router