### PR TITLE
fix: surface upstream image http errors

### DIFF
--- a/internal/relay/adaptor/openai/image.go
+++ b/internal/relay/adaptor/openai/image.go
@@ -3,10 +3,13 @@ package openai
 import (
 	"bytes"
 	"encoding/json"
-	"github.com/gin-gonic/gin"
-	"github.com/yeying-community/router/internal/relay/model"
+	"fmt"
 	"io"
 	"net/http"
+	"strings"
+
+	"github.com/gin-gonic/gin"
+	"github.com/yeying-community/router/internal/relay/model"
 )
 
 func ImageHandler(c *gin.Context, resp *http.Response) (*model.ErrorWithStatusCode, *model.Usage) {
@@ -19,6 +22,9 @@ func ImageHandler(c *gin.Context, resp *http.Response) (*model.ErrorWithStatusCo
 	err = resp.Body.Close()
 	if err != nil {
 		return ErrorWrapper(err, "close_response_body_failed", http.StatusInternalServerError), nil
+	}
+	if resp.StatusCode >= http.StatusBadRequest {
+		return wrapImageUpstreamError(resp, responseBody), nil
 	}
 	err = json.Unmarshal(responseBody, &imageResponse)
 	if err != nil {
@@ -41,4 +47,26 @@ func ImageHandler(c *gin.Context, resp *http.Response) (*model.ErrorWithStatusCo
 		return ErrorWrapper(err, "close_response_body_failed", http.StatusInternalServerError), nil
 	}
 	return nil, nil
+}
+
+func wrapImageUpstreamError(resp *http.Response, responseBody []byte) *model.ErrorWithStatusCode {
+	var errorResponse struct {
+		Error model.Error `json:"error"`
+	}
+	if err := json.Unmarshal(responseBody, &errorResponse); err == nil {
+		if strings.TrimSpace(errorResponse.Error.Message) != "" {
+			return &model.ErrorWithStatusCode{
+				Error:      errorResponse.Error,
+				StatusCode: resp.StatusCode,
+			}
+		}
+	}
+	return &model.ErrorWithStatusCode{
+		Error: model.Error{
+			Message: fmt.Sprintf("upstream returned %s", resp.Status),
+			Type:    "upstream_error",
+			Code:    "upstream_http_error",
+		},
+		StatusCode: resp.StatusCode,
+	}
 }

--- a/internal/relay/adaptor/openai/image_test.go
+++ b/internal/relay/adaptor/openai/image_test.go
@@ -1,0 +1,37 @@
+package openai
+
+import (
+	"io"
+	"net/http"
+	"strings"
+	"testing"
+)
+
+func TestImageHandlerWrapsNonJSONUpstreamError(t *testing.T) {
+	resp := &http.Response{
+		StatusCode: http.StatusBadGateway,
+		Status:     "502 Bad Gateway",
+		Header:     make(http.Header),
+		Body:       io.NopCloser(strings.NewReader("<html>bad gateway</html>")),
+	}
+
+	err, usage := ImageHandler(nil, resp)
+	if usage != nil {
+		t.Fatalf("usage = %+v, want nil", usage)
+	}
+	if err == nil {
+		t.Fatal("ImageHandler() error = nil, want upstream error")
+	}
+	if err.StatusCode != http.StatusBadGateway {
+		t.Fatalf("StatusCode = %d, want %d", err.StatusCode, http.StatusBadGateway)
+	}
+	if err.Type != "upstream_error" {
+		t.Fatalf("Type = %q, want upstream_error", err.Type)
+	}
+	if err.Code != "upstream_http_error" {
+		t.Fatalf("Code = %v, want upstream_http_error", err.Code)
+	}
+	if err.Message != "upstream returned 502 Bad Gateway" {
+		t.Fatalf("Message = %q", err.Message)
+	}
+}


### PR DESCRIPTION
## Summary
- preserve upstream HTTP status for image generation errors
- stop exposing JSON unmarshal failures when the upstream returns HTML or other non-JSON error pages
- add regression coverage for non-JSON upstream image failures

## Verification
- go test ./internal/relay/adaptor/openai ./internal/admin/controller ./internal/relay/controller
- go build -o /tmp/router ./cmd/router