### PR TITLE
fix: isolate react vendor chunk

### DIFF
--- a/web/vite.config.mjs
+++ b/web/vite.config.mjs
@@ -23,6 +23,13 @@ export default defineConfig({
             return undefined;
           }
           if (
+            id.includes('/react/') ||
+            id.includes('/react-dom/') ||
+            id.includes('/scheduler/')
+          ) {
+            return 'react';
+          }
+          if (
             id.includes('/react-router/') ||
             id.includes('/react-router-dom/') ||
             id.includes('/history/')


### PR DESCRIPTION
## Summary
- split React, ReactDOM, and scheduler into a dedicated Vite vendor chunk
- avoid antd/router chunk initialization cycles that can make createRoot undefined at startup

## Verification
- npm run build --prefix web
- go build -o /tmp/router ./cmd/router