### PR TITLE
fix: stabilize frontend vendor chunks and login logo

### DIFF
--- a/web/src/components/LoginForm.jsx
+++ b/web/src/components/LoginForm.jsx
@@ -139,7 +139,7 @@ const LoginForm = () => {
       <div className='router-login-floating-container'>
         <div className='router-login-top-banner'>
           <div className='router-login-top-banner-inner'>
-            <Image src={logo} className='router-login-top-banner-logo' />
+            <img src={logo} className='router-login-top-banner-logo' alt='' />
             <span>
               {loginBannerText}
               <a


### PR DESCRIPTION
## Summary
- split React, ReactDOM, and scheduler into a dedicated Vite vendor chunk
- avoid antd/router chunk initialization cycles that can make createRoot undefined at startup
- render the login logo with a native img element instead of an undefined Image component

## Verification
- npm run build --prefix web
- go build -o /tmp/router ./cmd/router