### PR TITLE
fix: improve token creation flow

### DIFF
--- a/web/src/components/TokensTable.jsx
+++ b/web/src/components/TokensTable.jsx
@@ -443,7 +443,7 @@ const TokensTable = () => {
               className='router-page-button'
               color='blue'
               as={Link}
-              to='/token/add'
+              to='/workspace/token/add'
             >
               {t('token.buttons.add')}
             </AppButton>

--- a/web/src/locales/en/translation.json
+++ b/web/src/locales/en/translation.json
@@ -1155,6 +1155,7 @@
       "messages": {
         "update_success": "Token updated successfully!",
         "create_success": "Token created successfully, please copy it from the list page!",
+        "name_required": "Please enter a token name.",
         "expire_time_invalid": "Invalid expiry time format!",
         "models_required": "Please select at least one model."
       }

--- a/web/src/locales/zh/translation.json
+++ b/web/src/locales/zh/translation.json
@@ -1155,6 +1155,7 @@
       "messages": {
         "update_success": "令牌更新成功！",
         "create_success": "令牌创建成功，请在列表页面点击复制获取令牌！",
+        "name_required": "请输入令牌名称。",
         "expire_time_invalid": "过期时间格式错误！",
         "models_required": "请至少选择一个模型。"
       }

--- a/web/src/pages/Token/EditToken.jsx
+++ b/web/src/pages/Token/EditToken.jsx
@@ -296,7 +296,10 @@ const EditToken = () => {
   }, [isDetailMode, loadAvailableModels, loadToken]);
 
   const submit = async () => {
-    if (isCreateMode && inputs.name === '') return;
+    if (isCreateMode && inputs.name.trim() === '') {
+      showError(t('token.edit.messages.name_required'));
+      return;
+    }
     const localInputs = { ...inputs };
     localInputs.remain_quota = parseInt(localInputs.remain_quota);
     if (localInputs.expired_time) {


### PR DESCRIPTION
## Summary
- route the token add button directly to the workspace token creation page
- show an explicit validation error when creating a token without a name
- add zh/en translations for the new token-name validation message

## Testing
- git diff --check
- npm run build --prefix web