### PR TITLE
fix: backfill synced channel models

### DIFF
--- a/internal/admin/controller/channel/async_task.go
+++ b/internal/admin/controller/channel/async_task.go
@@ -268,6 +268,11 @@ func executeChannelRefreshModelsTask(task *model.AsyncTask) (string, error) {
 	if err != nil {
 		return "", err
 	}
+	if len(fetchedRows) > 0 {
+		if err := model.AppendMissingFetchedChannelModelsWithDB(model.DB, channelID, fetchedRows); err != nil {
+			return "", err
+		}
+	}
 	if err := model.ReplaceChannelModelSyncResultsWithDB(model.DB, channelID, resolvedChannel.GetChannelModels(), fetchedRows, task.Id); err != nil {
 		return "", err
 	}

--- a/internal/admin/model/channel_billing.go
+++ b/internal/admin/model/channel_billing.go
@@ -655,7 +655,7 @@ func GetEffectiveChannelBillingProfileWithDB(db *gorm.DB, channel *Channel) (Cha
 		return row, false, nil
 	}
 	if errorsIsRecordNotFound(err) {
-		return ChannelBillingProfile{}, false, fmt.Errorf("渠道账务未配置")
+		return ChannelBillingProfile{}, false, nil
 	}
 	return ChannelBillingProfile{}, false, err
 }

--- a/internal/admin/model/channel_model.go
+++ b/internal/admin/model/channel_model.go
@@ -399,6 +399,72 @@ func SyncFetchedChannelModelsWithDB(db *gorm.DB, channelID string, fetchedRows [
 	return ReplaceChannelModelsWithDB(db, normalizedChannelID, rows)
 }
 
+func AppendMissingFetchedChannelModelsWithDB(db *gorm.DB, channelID string, fetchedRows []ChannelModel) error {
+	if db == nil {
+		return fmt.Errorf("database handle is nil")
+	}
+	normalizedChannelID := strings.TrimSpace(channelID)
+	if normalizedChannelID == "" {
+		return nil
+	}
+	existingRows, err := listChannelModelRowsByChannelIDWithDB(db, normalizedChannelID)
+	if err != nil {
+		return err
+	}
+	channelProtocol, err := loadChannelProtocolByChannelIDWithDB(db, normalizedChannelID)
+	if err != nil {
+		return err
+	}
+	normalizedExisting := NormalizeChannelModelsPreserveOrder(existingRows)
+	normalizedFetched := NormalizeChannelModelsPreserveOrder(fetchedRows)
+	existingKeys := make(map[string]struct{}, len(normalizedExisting)*2)
+	for _, row := range normalizedExisting {
+		modelName := strings.TrimSpace(row.Model)
+		upstreamModel := strings.TrimSpace(row.UpstreamModel)
+		if modelName != "" {
+			existingKeys["model:"+modelName] = struct{}{}
+		}
+		if upstreamModel != "" {
+			existingKeys["upstream:"+upstreamModel] = struct{}{}
+		}
+	}
+	nextRows := make([]ChannelModel, 0, len(normalizedExisting)+len(normalizedFetched))
+	nextRows = append(nextRows, normalizedExisting...)
+	for _, row := range normalizedFetched {
+		modelName := strings.TrimSpace(row.Model)
+		upstreamModel := strings.TrimSpace(row.UpstreamModel)
+		if upstreamModel == "" {
+			upstreamModel = modelName
+		}
+		if modelName == "" {
+			modelName = upstreamModel
+		}
+		if modelName == "" {
+			continue
+		}
+		if _, ok := existingKeys["model:"+modelName]; ok {
+			continue
+		}
+		if upstreamModel != "" {
+			if _, ok := existingKeys["upstream:"+upstreamModel]; ok {
+				continue
+			}
+		}
+		appended := row
+		appended.Model = modelName
+		appended.UpstreamModel = upstreamModel
+		appended.Selected = false
+		appended.Inactive = false
+		completeChannelModelRowDefaults(&appended, channelProtocol)
+		nextRows = append(nextRows, appended)
+		existingKeys["model:"+modelName] = struct{}{}
+		if upstreamModel != "" {
+			existingKeys["upstream:"+upstreamModel] = struct{}{}
+		}
+	}
+	return ReplaceChannelModelsWithDB(db, normalizedChannelID, nextRows)
+}
+
 func SyncFetchedChannelModelsFromBaseWithDB(db *gorm.DB, channelID string, baseRows []ChannelModel, fetchedRows []ChannelModel) error {
 	if db == nil {
 		return fmt.Errorf("database handle is nil")

--- a/web/src/locales/en/translation.json
+++ b/web/src/locales/en/translation.json
@@ -369,6 +369,7 @@
       "updated_at": "Updated At",
       "response_time": "Response Time",
       "capabilities": "Capabilities",
+      "billing": "Billing",
       "balance": "Balance",
       "priority": "Priority",
       "actions": "Actions",

--- a/web/src/locales/zh/translation.json
+++ b/web/src/locales/zh/translation.json
@@ -369,6 +369,7 @@
       "updated_at": "更新时间",
       "response_time": "响应时间",
       "capabilities": "能力",
+      "billing": "账务",
       "balance": "余额",
       "priority": "优先级",
       "actions": "操作",


### PR DESCRIPTION
## Summary
- stop erroring when a channel billing profile is missing and return an empty profile instead
- append models missing from channel_models after sync, defaulting them to unselected
- add the missing channel.table.billing locale entries

## Verification
- go test ./internal/admin/model/... ./internal/admin/controller/channel/...
- npm run build
