### PR TITLE
Support direct robot notifications

### DIFF
--- a/common/config/config.go
+++ b/common/config/config.go
@@ -130,8 +130,10 @@ var UcanTrustedIssuerDIDs []string
 // CORS allowlist (comma-separated env CORS_ALLOWED_ORIGINS)
 var CorsAllowedOrigins []string
 
-var MessagePusherAddress = ""
-var MessagePusherToken = ""
+var NotifyProvider = ""
+var NotifyWebhookURL = ""
+var NotifySecret = ""
+var NotifyToken = ""
 
 var TurnstileSiteKey = ""
 var TurnstileSecretKey = ""

--- a/common/config_loader.go
+++ b/common/config_loader.go
@@ -41,6 +41,7 @@ type AppConfig struct {
 	UCAN      UCANConfig      `yaml:"ucan"`
 	Feature   FeatureConfig   `yaml:"feature"`
 	Operation OperationConfig `yaml:"operation"`
+	Notify    NotifyConfig    `yaml:"notify"`
 	Relay     RelayConfig     `yaml:"relay"`
 	RateLimit RateLimitConfig `yaml:"rate_limit"`
 	Metrics   MetricsConfig   `yaml:"metrics"`
@@ -126,6 +127,13 @@ type OperationConfig struct {
 	TopUpSignSecret        string `yaml:"top_up_sign_secret"`
 	TopUpCallbackToken     string `yaml:"top_up_callback_token"`
 	ChatLink               string `yaml:"chat_link"`
+}
+
+type NotifyConfig struct {
+	Provider   string `yaml:"provider"`
+	WebhookURL string `yaml:"webhook_url"`
+	Secret     string `yaml:"secret"`
+	Token      string `yaml:"token"`
 }
 
 type RelayConfig struct {
@@ -239,6 +247,12 @@ func defaultAppConfig() AppConfig {
 			TopUpCallbackToken:     "",
 			ChatLink:               "",
 		},
+		Notify: NotifyConfig{
+			Provider:   "",
+			WebhookURL: "",
+			Secret:     "",
+			Token:      "",
+		},
 		Relay: RelayConfig{
 			TimeoutSeconds:                         0,
 			Proxy:                                  "",
@@ -330,6 +344,10 @@ func ApplyAppConfig(cfg *AppConfig, portFlagSet bool, logDirFlagSet bool) error 
 	config.TopUpSignSecret = strings.TrimSpace(cfg.Operation.TopUpSignSecret)
 	config.TopUpCallbackToken = strings.TrimSpace(cfg.Operation.TopUpCallbackToken)
 	config.ChatLink = strings.TrimSpace(cfg.Operation.ChatLink)
+	config.NotifyProvider = strings.ToLower(strings.TrimSpace(cfg.Notify.Provider))
+	config.NotifyWebhookURL = strings.TrimSpace(cfg.Notify.WebhookURL)
+	config.NotifySecret = strings.TrimSpace(cfg.Notify.Secret)
+	config.NotifyToken = strings.TrimSpace(cfg.Notify.Token)
 
 	SQLDSN = strings.TrimSpace(cfg.Database.SQLDSN)
 	LogSQLDSN = strings.TrimSpace(cfg.Database.LogSQLDSN)

--- a/common/message/main.go
+++ b/common/message/main.go
@@ -9,13 +9,15 @@ const (
 	ByAll           = "all"
 	ByEmail         = "email"
 	ByMessagePusher = "message_pusher"
+	ByDingTalk      = "dingtalk"
+	ByLark          = "lark"
 )
 
 func Notify(by string, title string, description string, content string) error {
 	if by == ByEmail {
 		return SendEmail(title, config.RootUserEmail, content)
 	}
-	if by == ByMessagePusher {
+	if by == ByMessagePusher || by == ByDingTalk || by == ByLark {
 		return SendMessage(title, description, content)
 	}
 	return fmt.Errorf("unknown notify method: %s", by)

--- a/common/message/message-pusher.go
+++ b/common/message/message-pusher.go
@@ -2,10 +2,20 @@ package message
 
 import (
 	"bytes"
+	"crypto/hmac"
+	"crypto/sha256"
+	"encoding/base64"
 	"encoding/json"
 	"errors"
+	"fmt"
 	"github.com/yeying-community/router/common/config"
+	"html"
+	"io"
 	"net/http"
+	"net/url"
+	"regexp"
+	"strings"
+	"time"
 )
 
 type request struct {
@@ -23,24 +33,41 @@ type response struct {
 }
 
 func SendMessage(title string, description string, content string) error {
-	if config.MessagePusherAddress == "" {
-		return errors.New("message pusher address is not set")
+	provider := strings.ToLower(strings.TrimSpace(config.NotifyProvider))
+	if provider == "" {
+		return errors.New("notify provider is not set")
+	}
+	switch provider {
+	case "message_pusher":
+		return sendMessagePusher(title, description, content)
+	case "dingtalk":
+		return sendDingTalkMessage(title, description, content)
+	case "lark":
+		return sendLarkMessage(title, description, content)
+	default:
+		return fmt.Errorf("unsupported notify provider: %s", provider)
+	}
+}
+
+func sendMessagePusher(title string, description string, content string) error {
+	if config.NotifyWebhookURL == "" {
+		return errors.New("notify webhook url is not set")
 	}
 	req := request{
 		Title:       title,
 		Description: description,
 		Content:     content,
-		Token:       config.MessagePusherToken,
+		Token:       config.NotifyToken,
 	}
 	data, err := json.Marshal(req)
 	if err != nil {
 		return err
 	}
-	resp, err := http.Post(config.MessagePusherAddress,
-		"application/json", bytes.NewBuffer(data))
+	resp, err := http.Post(config.NotifyWebhookURL, "application/json", bytes.NewBuffer(data))
 	if err != nil {
 		return err
 	}
+	defer resp.Body.Close()
 	var res response
 	err = json.NewDecoder(resp.Body).Decode(&res)
 	if err != nil {
@@ -50,4 +77,127 @@ func SendMessage(title string, description string, content string) error {
 		return errors.New(res.Message)
 	}
 	return nil
+}
+
+func sendDingTalkMessage(title string, description string, content string) error {
+	if config.NotifyWebhookURL == "" {
+		return errors.New("notify webhook url is not set")
+	}
+	requestURL := strings.TrimSpace(config.NotifyWebhookURL)
+	if secret := strings.TrimSpace(config.NotifySecret); secret != "" {
+		timestamp := fmt.Sprintf("%d", time.Now().UnixMilli())
+		stringToSign := timestamp + "\n" + secret
+		mac := hmac.New(sha256.New, []byte(secret))
+		_, _ = mac.Write([]byte(stringToSign))
+		sign := url.QueryEscape(base64.StdEncoding.EncodeToString(mac.Sum(nil)))
+		separator := "&"
+		if !strings.Contains(requestURL, "?") {
+			separator = "?"
+		}
+		requestURL = fmt.Sprintf("%s%stimestamp=%s&sign=%s", requestURL, separator, timestamp, sign)
+	}
+	body := map[string]any{
+		"msgtype": "markdown",
+		"markdown": map[string]string{
+			"title": title,
+			"text":  formatRobotMarkdown(title, description, content),
+		},
+	}
+	return postJSONWithRobotResponse(requestURL, body)
+}
+
+func sendLarkMessage(title string, description string, content string) error {
+	if config.NotifyWebhookURL == "" {
+		return errors.New("notify webhook url is not set")
+	}
+	body := map[string]any{
+		"msg_type": "text",
+		"content": map[string]string{
+			"text": formatRobotText(title, description, content),
+		},
+	}
+	if secret := strings.TrimSpace(config.NotifySecret); secret != "" {
+		timestamp := fmt.Sprintf("%d", time.Now().Unix())
+		stringToSign := timestamp + "\n" + secret
+		mac := hmac.New(sha256.New, []byte(stringToSign))
+		_, _ = mac.Write([]byte{})
+		body["timestamp"] = timestamp
+		body["sign"] = base64.StdEncoding.EncodeToString(mac.Sum(nil))
+	}
+	return postJSONWithRobotResponse(strings.TrimSpace(config.NotifyWebhookURL), body)
+}
+
+func postJSONWithRobotResponse(requestURL string, payload any) error {
+	data, err := json.Marshal(payload)
+	if err != nil {
+		return err
+	}
+	resp, err := http.Post(requestURL, "application/json", bytes.NewBuffer(data))
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return err
+	}
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		return fmt.Errorf("notify request failed: http %d: %s", resp.StatusCode, strings.TrimSpace(string(body)))
+	}
+	var envelope struct {
+		ErrCode       int    `json:"errcode"`
+		ErrMsg        string `json:"errmsg"`
+		Code          int    `json:"code"`
+		Msg           string `json:"msg"`
+		StatusCode    int    `json:"StatusCode"`
+		StatusMessage string `json:"StatusMessage"`
+	}
+	if err := json.Unmarshal(body, &envelope); err == nil {
+		if envelope.ErrCode != 0 {
+			return fmt.Errorf("notify request failed: %s", strings.TrimSpace(envelope.ErrMsg))
+		}
+		if envelope.Code != 0 {
+			return fmt.Errorf("notify request failed: %s", strings.TrimSpace(envelope.Msg))
+		}
+		if envelope.StatusCode != 0 {
+			return fmt.Errorf("notify request failed: %s", strings.TrimSpace(envelope.StatusMessage))
+		}
+	}
+	return nil
+}
+
+func formatRobotMarkdown(title string, description string, content string) string {
+	text := normalizeTextContent(description, content)
+	if text == "" {
+		return "### " + strings.TrimSpace(title)
+	}
+	return "### " + strings.TrimSpace(title) + "\n\n" + strings.ReplaceAll(text, "\n", "\n\n")
+}
+
+func formatRobotText(title string, description string, content string) string {
+	text := normalizeTextContent(description, content)
+	if text == "" {
+		return strings.TrimSpace(title)
+	}
+	return strings.TrimSpace(title) + "\n" + text
+}
+
+var htmlTagPattern = regexp.MustCompile(`(?s)<[^>]*>`)
+
+func normalizeTextContent(description string, content string) string {
+	plain := strings.TrimSpace(description)
+	if plain == "" {
+		plain = strings.TrimSpace(content)
+	}
+	plain = html.UnescapeString(htmlTagPattern.ReplaceAllString(plain, "\n"))
+	lines := strings.Split(plain, "\n")
+	normalized := make([]string, 0, len(lines))
+	for _, line := range lines {
+		line = strings.TrimSpace(line)
+		if line == "" {
+			continue
+		}
+		normalized = append(normalized, line)
+	}
+	return strings.Join(normalized, "\n")
 }

--- a/config.yaml.template
+++ b/config.yaml.template
@@ -166,6 +166,22 @@ operation:
   # 用户工作区“聊天”入口 URL；留空则不展示该菜单。
   chat_link: ""
 
+notify:
+  # 通知通道：
+  # - dingtalk：钉钉机器人 WebHook
+  # - lark：飞书机器人 WebHook
+  # - message_pusher：Router 旧的中转推送服务
+  provider: ""
+  # 机器人 WebHook 地址或 message_pusher 地址。
+  webhook_url: ""
+  # 机器人签名密钥：
+  # - dingtalk：机器人加签密钥（SEC...）
+  # - lark：机器人签名密钥
+  # - message_pusher：留空
+  secret: ""
+  # 仅 message_pusher 使用的鉴权 token。
+  token: ""
+
 relay:
   # 上游请求总超时（秒）；0 表示使用默认策略。
   timeout_seconds: 0

--- a/internal/admin/controller/channel/async_task.go
+++ b/internal/admin/controller/channel/async_task.go
@@ -11,6 +11,7 @@ import (
 	"github.com/yeying-community/router/common/helper"
 	"github.com/yeying-community/router/common/logger"
 	"github.com/yeying-community/router/internal/admin/model"
+	"github.com/yeying-community/router/internal/admin/monitor"
 	channelsvc "github.com/yeying-community/router/internal/admin/service/channel"
 )
 
@@ -374,6 +375,7 @@ func executeChannelRefreshBillingTask(task *model.AsyncTask) (string, error) {
 		if err != nil {
 			return "", err
 		}
+		disableChannelForScheduledBillingInsufficientBalance(task, channelRow, primaryAmount)
 		return marshalJSONForLog(map[string]any{
 			"channel_id":           channelID,
 			"billing_mode":         model.ChannelBillingModeBuiltinCDK,
@@ -389,6 +391,7 @@ func executeChannelRefreshBillingTask(task *model.AsyncTask) (string, error) {
 	if err := persistChannelAutoBillingSnapshot(channelRow, primaryAmount, "自动刷新账务"); err != nil {
 		return "", err
 	}
+	disableChannelForScheduledBillingInsufficientBalance(task, channelRow, primaryAmount)
 	return marshalJSONForLog(map[string]any{
 		"channel_id":           channelID,
 		"billing_api_base_url": resolveChannelBillingAPIBaseURL(channelRow, profile),
@@ -396,6 +399,19 @@ func executeChannelRefreshBillingTask(task *model.AsyncTask) (string, error) {
 		"billing_request_urls": resolveChannelBillingRequestURLs(channelRow),
 		"primary_amount":       primaryAmount,
 	}), nil
+}
+
+func disableChannelForScheduledBillingInsufficientBalance(task *model.AsyncTask, channelRow *model.Channel, primaryAmount float64) {
+	if task == nil || channelRow == nil {
+		return
+	}
+	if strings.TrimSpace(task.CreatedBy) != "" {
+		return
+	}
+	if primaryAmount > 0 {
+		return
+	}
+	monitor.DisableChannelForInsufficientBalance(channelRow.Id, channelRow.DisplayName(), primaryAmount)
 }
 
 func logChannelAsyncTestExecution(task *model.AsyncTask, result model.ChannelTest, execution channelModelTestExecution) {

--- a/internal/admin/controller/channel/billing.go
+++ b/internal/admin/controller/channel/billing.go
@@ -690,7 +690,7 @@ func refreshAllChannelsBilling() error {
 		if strings.TrimSpace(profile.BillingMode) == model.ChannelBillingModeBuiltinCDK {
 			primaryAmount, err := refreshAndPersistChannelCDKBilling(channel, profile, "批量自动刷新账务")
 			if err == nil && primaryAmount <= 0 {
-				monitor.DisableChannel(channel.Id, channel.DisplayName(), "余额不足")
+				monitor.DisableChannelForInsufficientBalance(channel.Id, channel.DisplayName(), primaryAmount)
 			}
 			time.Sleep(config.RequestInterval)
 			continue
@@ -703,7 +703,7 @@ func refreshAllChannelsBilling() error {
 				continue
 			}
 			if primaryAmount <= 0 {
-				monitor.DisableChannel(channel.Id, channel.DisplayName(), "余额不足")
+				monitor.DisableChannelForInsufficientBalance(channel.Id, channel.DisplayName(), primaryAmount)
 			}
 		}
 		time.Sleep(config.RequestInterval)

--- a/internal/admin/monitor/channel.go
+++ b/internal/admin/monitor/channel.go
@@ -44,6 +44,23 @@ func DisableChannel(channelId string, channelName string, reason string) {
 	notifyRootUser(subject, content)
 }
 
+func DisableChannelForInsufficientBalance(channelId string, channelName string, balance float64) {
+	model.UpdateChannelStatusById(channelId, model.ChannelStatusAutoDisabled)
+	logger.SysLog(fmt.Sprintf("channel #%s has been disabled due to insufficient balance: %.4f", channelId, balance))
+	subject := fmt.Sprintf("渠道余额不足提醒")
+	content := message.EmailTemplate(
+		subject,
+		fmt.Sprintf(`
+			<p>您好！</p>
+			<p>渠道「<strong>%s</strong>」（#%s）定时刷新账务后发现余额不足，已被系统自动禁用。</p>
+			<p>当前余额：</p>
+			<p style="background-color: #f8f8f8; padding: 10px; border-radius: 4px;"><strong>%.4f</strong></p>
+			<p>请及时检查上游账户余额或补充采购记录。</p>
+		`, channelName, channelId, balance),
+	)
+	notifyRootUser(subject, content)
+}
+
 func MetricDisableChannel(channelId string, successRate float64) {
 	model.UpdateChannelStatusById(channelId, model.ChannelStatusAutoDisabled)
 	logger.SysLog(fmt.Sprintf("channel #%s has been disabled due to low success rate: %.2f", channelId, successRate*100))

--- a/internal/admin/monitor/channel.go
+++ b/internal/admin/monitor/channel.go
@@ -2,6 +2,7 @@ package monitor
 
 import (
 	"fmt"
+	"strings"
 
 	"github.com/yeying-community/router/common/config"
 	"github.com/yeying-community/router/common/logger"
@@ -10,7 +11,7 @@ import (
 )
 
 func notifyRootUser(subject string, content string) {
-	if config.MessagePusherAddress != "" {
+	if strings.TrimSpace(config.NotifyProvider) != "" && strings.TrimSpace(config.NotifyWebhookURL) != "" {
 		err := message.SendMessage(subject, content, content)
 		if err != nil {
 			logger.SysError(fmt.Sprintf("failed to send message: %s", err.Error()))

--- a/internal/transport/http/middleware/utils.go
+++ b/internal/transport/http/middleware/utils.go
@@ -55,6 +55,11 @@ func getRequestModel(c *gin.Context) (string, error) {
 			modelRequest.Model = "dall-e-2"
 		}
 	}
+	if strings.HasPrefix(path, "/v1/images/edits") && modelRequest.Model == "" {
+		if modelValue := strings.TrimSpace(c.PostForm("model")); modelValue != "" {
+			modelRequest.Model = modelValue
+		}
+	}
 	if strings.HasPrefix(path, "/v1/audio/transcriptions") || strings.HasPrefix(path, "/v1/audio/translations") {
 		if modelRequest.Model == "" {
 			modelRequest.Model = "whisper-1"

--- a/internal/transport/http/middleware/utils_test.go
+++ b/internal/transport/http/middleware/utils_test.go
@@ -38,6 +38,42 @@ func TestGetRequestModel_VideosMultipart(t *testing.T) {
 	}
 }
 
+func TestGetRequestModel_ImageEditsMultipart(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	body := &bytes.Buffer{}
+	writer := multipart.NewWriter(body)
+	if err := writer.WriteField("model", "qwen-image-2.0"); err != nil {
+		t.Fatalf("WriteField(model) error: %v", err)
+	}
+	if err := writer.WriteField("prompt", "make it blue"); err != nil {
+		t.Fatalf("WriteField(prompt) error: %v", err)
+	}
+	part, err := writer.CreateFormFile("image", "test.png")
+	if err != nil {
+		t.Fatalf("CreateFormFile(image) error: %v", err)
+	}
+	if _, err := part.Write([]byte{0x89, 0x50, 0x4e, 0x47}); err != nil {
+		t.Fatalf("Write(image) error: %v", err)
+	}
+	if err := writer.Close(); err != nil {
+		t.Fatalf("writer.Close error: %v", err)
+	}
+
+	req := httptest.NewRequest("POST", "/v1/images/edits", body)
+	req.Header.Set("Content-Type", writer.FormDataContentType())
+	c, _ := gin.CreateTestContext(httptest.NewRecorder())
+	c.Request = req
+
+	modelName, err := getRequestModel(c)
+	if err != nil {
+		t.Fatalf("getRequestModel returned error: %v", err)
+	}
+	if modelName != "qwen-image-2.0" {
+		t.Fatalf("getRequestModel returned %q, want %q", modelName, "qwen-image-2.0")
+	}
+}
+
 func TestGetRequestModel_VideoStatusQuery(t *testing.T) {
 	gin.SetMode(gin.TestMode)
 

--- a/web/src/pages/Log/Detail.jsx
+++ b/web/src/pages/Log/Detail.jsx
@@ -185,10 +185,10 @@ const LogDetail = () => {
       <AppFilterHeader
         breadcrumbs={[
           {
-            key: 'workspace',
+            key: 'section',
             label: isAdminPage
-              ? t('header.admin_workspace')
-              : t('header.user_workspace'),
+              ? t('header.platform_operation')
+              : t('header.records'),
           },
           {
             key: 'log-list',

--- a/web/src/pages/Setting/index.jsx
+++ b/web/src/pages/Setting/index.jsx
@@ -19,6 +19,13 @@ const Setting = () => {
   if (!isAdminWorkspace) {
     return (
       <div className='dashboard-container'>
+        <AppFilterHeader
+          breadcrumbs={[
+            { key: 'mine', label: t('header.mine') },
+            { key: 'account', label: t('header.account'), active: true },
+          ]}
+          title={t('header.account')}
+        />
         <AppSection>
           <PersonalSetting />
         </AppSection>


### PR DESCRIPTION
## Summary
- support direct notify providers for dingtalk, lark, and message_pusher
- load notify provider/webhook/secret/token from config.yaml
- route channel insufficient-balance notifications through the unified notify config

## Verification
- go test ./common ./common/message ./internal/admin/controller/channel ./internal/admin/monitor
- verified DingTalk robot webhook returns errcode=0 in a manual simulated send