### PR TITLE
fix(web): align dashboard and user detail controls

### DIFF
--- a/web/src/index.css
+++ b/web/src/index.css
@@ -1151,6 +1151,18 @@ body,
     width: 100%;
 }
 
+.router-ui-field-control > .router-ui-select.router-section-input,
+.router-ui-field-control > .router-ui-select.router-section-input .ant-select-selector {
+    min-height: 38px !important;
+    height: 38px !important;
+}
+
+.router-ui-field-control > .router-ui-select.router-section-input .ant-select-selector {
+    display: flex !important;
+    align-items: center !important;
+    border-radius: 10px !important;
+}
+
 .router-ui-select.router-modal-dropdown .ant-select-selector {
     border-radius: 10px !important;
     display: flex !important;
@@ -1845,7 +1857,8 @@ body,
 }
 
 .router-inline-meta-card {
-    min-height: 36px;
+    min-height: 38px;
+    height: 38px;
     display: flex;
     align-items: center;
     justify-content: space-between;
@@ -1853,15 +1866,18 @@ body,
     border: 1px solid rgba(34, 36, 38, 0.1);
     border-radius: 10px;
     background: #fafbfc;
-    padding: 8px 10px;
+    padding: 0 10px;
 }
 
 .router-inline-meta-value {
     flex: 1 1 auto;
     min-width: 0;
     font-size: 12px;
-    line-height: 1.45;
+    line-height: 1.35;
     color: #1f2937;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
     word-break: break-all;
 }
 

--- a/web/src/pages/AdminDashboard/AdminDashboard.css
+++ b/web/src/pages/AdminDashboard/AdminDashboard.css
@@ -20,8 +20,7 @@
 }
 
 .admin-dashboard-toolbar .router-toolbar-meta {
-  color: #6b7280;
-  font-size: 12px;
+  display: none;
 }
 
 .admin-dashboard-toolbar .router-filter-toolbar {
@@ -32,13 +31,7 @@
 .admin-dashboard-period {
   display: inline-flex;
   align-items: center;
-  gap: 8px;
-}
-
-.admin-dashboard-period-label {
-  color: #6b7280;
-  font-size: 12px;
-  white-space: nowrap;
+  height: 32px;
 }
 
 .admin-dashboard-toolbar-end {
@@ -48,9 +41,33 @@
   flex-wrap: wrap;
 }
 
-.admin-dashboard-updated {
-  font-size: 12px;
+.admin-dashboard-generated-at {
   color: #6b7280;
+  font-size: 12px;
+  line-height: 32px;
+  white-space: nowrap;
+}
+
+.admin-dashboard-toolbar .router-ui-select.router-section-dropdown,
+.admin-dashboard-toolbar .router-ui-select.router-section-dropdown .ant-select-selector,
+.admin-dashboard-toolbar .router-ui-button.router-inline-button {
+  min-height: 32px !important;
+  height: 32px !important;
+}
+
+.admin-dashboard-toolbar .router-ui-select.router-section-dropdown {
+  min-width: 132px;
+}
+
+.admin-dashboard-toolbar .router-ui-select.router-section-dropdown .ant-select-selector {
+  align-items: center;
+}
+
+.admin-dashboard-toolbar .router-ui-button.router-inline-button {
+  display: inline-flex !important;
+  align-items: center !important;
+  padding-top: 0 !important;
+  padding-bottom: 0 !important;
 }
 
 .admin-dashboard-kpi-grid {

--- a/web/src/pages/AdminDashboard/index.jsx
+++ b/web/src/pages/AdminDashboard/index.jsx
@@ -799,14 +799,8 @@ const AdminDashboard = () => {
         { key: activeSection, label: activeSectionTitle, active: true },
       ]}
       title={activeSectionTitle}
-      meta={t('dashboard.admin.updated_at', {
-        time: formatUpdatedAt(dashboard.generated_at),
-      })}
       picker={
         <div className='admin-dashboard-period'>
-          <span className='admin-dashboard-period-label'>
-            {t('dashboard.admin.period.label')}
-          </span>
           <AppSelect
             className='router-section-dropdown'
             options={periodOptions}
@@ -816,14 +810,19 @@ const AdminDashboard = () => {
         </div>
       }
       actions={
-        <AppButton
-          className='router-inline-button'
-          type='button'
-          loading={loading}
-          onClick={loadData}
-        >
-          {t('dashboard.admin.buttons.refresh')}
-        </AppButton>
+        <>
+          <span className='admin-dashboard-generated-at'>
+            {formatUpdatedAt(dashboard.generated_at)}
+          </span>
+          <AppButton
+            className='router-inline-button'
+            type='button'
+            loading={loading}
+            onClick={loadData}
+          >
+            {t('dashboard.admin.buttons.refresh')}
+          </AppButton>
+        </>
       }
       endClassName='admin-dashboard-toolbar-end'
     />

--- a/web/src/pages/User/EditUser.jsx
+++ b/web/src/pages/User/EditUser.jsx
@@ -1241,7 +1241,7 @@ const UserDetail = () => {
                     </AppField>
                   )}
                   <AppField label={t('user.table.role_text')}>
-                    <div>{roleControl}</div>
+                    {roleControl}
                   </AppField>
                 </AppFormRow>
 


### PR DESCRIPTION
## Summary
- remove dashboard header labels while keeping generated time next to refresh
- align dashboard period selector and refresh button sizing
- normalize user detail basic-info select and readonly control heights

## Tests
- npm run build