### PR TITLE
Support Responses image generation channel tests

### DIFF
--- a/internal/admin/controller/channel/async_task.go
+++ b/internal/admin/controller/channel/async_task.go
@@ -18,13 +18,14 @@ import (
 )
 
 type channelModelTestTaskPayload struct {
-	ChannelID     string `json:"channel_id"`
-	Model         string `json:"model"`
-	Endpoint      string `json:"endpoint"`
-	IsStream      *bool  `json:"is_stream,omitempty"`
-	AudioLanguage string `json:"audio_language,omitempty"`
-	ImageEditURL  string `json:"image_edit_url,omitempty"`
-	ImageEditData string `json:"image_edit_data,omitempty"`
+	ChannelID         string `json:"channel_id"`
+	Model             string `json:"model"`
+	Endpoint          string `json:"endpoint"`
+	IsStream          *bool  `json:"is_stream,omitempty"`
+	AudioLanguage     string `json:"audio_language,omitempty"`
+	ImageEditURL      string `json:"image_edit_url,omitempty"`
+	ImageEditData     string `json:"image_edit_data,omitempty"`
+	ResponsesTestMode string `json:"responses_test_mode,omitempty"`
 }
 
 type channelRefreshModelsTaskPayload struct {
@@ -35,16 +36,20 @@ type channelRefreshBillingTaskPayload struct {
 	ChannelID string `json:"channel_id"`
 }
 
-func buildChannelModelTestTaskDedupeKey(channelID string, modelID string, endpoint string, streamOverride *bool, audioLanguage string, imageEditURL string, imageEditData string) string {
+func buildChannelModelTestTaskDedupeKey(channelID string, modelID string, endpoint string, streamOverride *bool, audioLanguage string, imageEditURL string, imageEditData string, responsesTestMode string) string {
 	normalizedModelID := strings.TrimSpace(modelID)
 	normalizedEndpoint := model.NormalizeRequestedChannelModelEndpoint(endpoint)
 	normalizedAudioLanguage := normalizeAudioTestLanguage(audioLanguage)
 	imageEditSignature := channelModelTestImageEditSignature(normalizedEndpoint, imageEditURL, imageEditData)
+	normalizedResponsesTestMode := ""
+	if normalizedEndpoint == model.ChannelModelEndpointResponses {
+		normalizedResponsesTestMode = normalizeResponsesTestMode(responsesTestMode)
+	}
 	if streamOverride == nil {
-		if normalizedAudioLanguage == "zh-CN" && imageEditSignature == "" {
+		if normalizedAudioLanguage == "zh-CN" && imageEditSignature == "" && normalizedResponsesTestMode == "" {
 			return fmt.Sprintf("%s:%s:%s:%s", model.AsyncTaskTypeChannelModelTest, strings.TrimSpace(channelID), normalizedModelID, normalizedEndpoint)
 		}
-		return fmt.Sprintf("%s:%s:%s:%s:%s:%s", model.AsyncTaskTypeChannelModelTest, strings.TrimSpace(channelID), normalizedModelID, normalizedEndpoint, normalizedAudioLanguage, imageEditSignature)
+		return fmt.Sprintf("%s:%s:%s:%s:%s:%s:%s", model.AsyncTaskTypeChannelModelTest, strings.TrimSpace(channelID), normalizedModelID, normalizedEndpoint, normalizedAudioLanguage, imageEditSignature, normalizedResponsesTestMode)
 	}
 	key := fmt.Sprintf(
 		"%s:%s:%s:%s:%t",
@@ -59,6 +64,9 @@ func buildChannelModelTestTaskDedupeKey(channelID string, modelID string, endpoi
 	}
 	if imageEditSignature != "" {
 		key = fmt.Sprintf("%s:%s", key, imageEditSignature)
+	}
+	if normalizedResponsesTestMode != "" {
+		key = fmt.Sprintf("%s:%s", key, normalizedResponsesTestMode)
 	}
 	return key
 }
@@ -86,15 +94,16 @@ func buildChannelRefreshBillingTaskDedupeKey(channelID string) string {
 	return fmt.Sprintf("%s:%s", model.AsyncTaskTypeChannelRefreshBilling, strings.TrimSpace(channelID))
 }
 
-func buildChannelModelTestTaskPayload(modelID string, channelID string, endpoint string, streamOverride *bool, audioLanguage string, imageEditURL string, imageEditData string) string {
+func buildChannelModelTestTaskPayload(modelID string, channelID string, endpoint string, streamOverride *bool, audioLanguage string, imageEditURL string, imageEditData string, responsesTestMode string) string {
 	return marshalJSONForLog(channelModelTestTaskPayload{
-		ChannelID:     strings.TrimSpace(channelID),
-		Model:         strings.TrimSpace(modelID),
-		Endpoint:      model.NormalizeRequestedChannelModelEndpoint(endpoint),
-		IsStream:      streamOverride,
-		AudioLanguage: normalizeAudioTestLanguage(audioLanguage),
-		ImageEditURL:  strings.TrimSpace(imageEditURL),
-		ImageEditData: strings.TrimSpace(imageEditData),
+		ChannelID:         strings.TrimSpace(channelID),
+		Model:             strings.TrimSpace(modelID),
+		Endpoint:          model.NormalizeRequestedChannelModelEndpoint(endpoint),
+		IsStream:          streamOverride,
+		AudioLanguage:     normalizeAudioTestLanguage(audioLanguage),
+		ImageEditURL:      strings.TrimSpace(imageEditURL),
+		ImageEditData:     strings.TrimSpace(imageEditData),
+		ResponsesTestMode: normalizeResponsesTestMode(responsesTestMode),
 	})
 }
 
@@ -121,6 +130,7 @@ func CreateChannelModelTestTasks(channelID string, createdBy string, requestedTe
 	reusedCount := 0
 	endpointOverrides := make(map[string]string, len(requestedConfigs))
 	streamOverrides := make(map[string]*bool, len(requestedConfigs))
+	responsesTestModeOverrides := make(map[string]string, len(requestedConfigs))
 	for _, item := range requestedConfigs {
 		modelID := strings.TrimSpace(item.Model)
 		if modelID == "" {
@@ -128,6 +138,7 @@ func CreateChannelModelTestTasks(channelID string, createdBy string, requestedTe
 		}
 		endpointOverrides[modelID] = strings.TrimSpace(item.Endpoint)
 		streamOverrides[modelID] = item.IsStream
+		responsesTestModeOverrides[modelID] = normalizeResponsesTestMode(item.ResponsesTestMode)
 	}
 	for _, row := range targetRows {
 		endpoint := endpointOverrides[strings.TrimSpace(row.Model)]
@@ -145,6 +156,10 @@ func CreateChannelModelTestTasks(channelID string, createdBy string, requestedTe
 		if resolveSelectionModelType(row) == model.ProviderModelTypeAudio {
 			stream = nil
 		}
+		responsesTestMode := ""
+		if normalizedEndpoint == model.ChannelModelEndpointResponses {
+			responsesTestMode = responsesTestModeOverrides[strings.TrimSpace(row.Model)]
+		}
 		imageEditURL := ""
 		imageEditData := ""
 		if normalizedEndpoint == model.ChannelModelEndpointImageEdit {
@@ -154,11 +169,11 @@ func CreateChannelModelTestTasks(channelID string, createdBy string, requestedTe
 		modelID := strings.TrimSpace(row.Model)
 		task, reused, err := model.CreateOrReuseAsyncTaskWithDB(model.DB, model.AsyncTask{
 			Type:      model.AsyncTaskTypeChannelModelTest,
-			DedupeKey: buildChannelModelTestTaskDedupeKey(normalizedChannelID, modelID, normalizedEndpoint, stream, normalizedAudioLanguage, imageEditURL, imageEditData),
+			DedupeKey: buildChannelModelTestTaskDedupeKey(normalizedChannelID, modelID, normalizedEndpoint, stream, normalizedAudioLanguage, imageEditURL, imageEditData, responsesTestMode),
 			ChannelId: normalizedChannelID,
 			Model:     modelID,
 			Endpoint:  normalizedEndpoint,
-			Payload:   buildChannelModelTestTaskPayload(modelID, normalizedChannelID, normalizedEndpoint, stream, normalizedAudioLanguage, imageEditURL, imageEditData),
+			Payload:   buildChannelModelTestTaskPayload(modelID, normalizedChannelID, normalizedEndpoint, stream, normalizedAudioLanguage, imageEditURL, imageEditData, responsesTestMode),
 			CreatedBy: strings.TrimSpace(createdBy),
 			TraceID:   strings.TrimSpace(traceID),
 		})
@@ -375,7 +390,7 @@ func executeChannelModelTestTask(ctx context.Context, task *model.AsyncTask) (st
 	testResult, execution := runSingleChannelModelTestWithContextAndStream(ctx, channelRow, row, payload.IsStream, payload.AudioLanguage, imageEditTestInput{
 		URL:     payload.ImageEditURL,
 		DataURI: payload.ImageEditData,
-	})
+	}, payload.ResponsesTestMode)
 	testResult.ChannelId = channelID
 	persistChannelTestArtifactForExecution(ctx, task.Id, &testResult, &execution)
 	logChannelAsyncTestExecution(task, testResult, execution)

--- a/internal/admin/controller/channel/model_testing.go
+++ b/internal/admin/controller/channel/model_testing.go
@@ -42,9 +42,24 @@ type imageEditTestInput struct {
 }
 
 type channelModelTestTargetItem struct {
-	Model    string `json:"model"`
-	Endpoint string `json:"endpoint,omitempty"`
-	IsStream *bool  `json:"is_stream,omitempty"`
+	Model             string `json:"model"`
+	Endpoint          string `json:"endpoint,omitempty"`
+	IsStream          *bool  `json:"is_stream,omitempty"`
+	ResponsesTestMode string `json:"responses_test_mode,omitempty"`
+}
+
+const (
+	channelModelResponsesTestModeText            = "text"
+	channelModelResponsesTestModeImageGeneration = "image_generation"
+)
+
+func normalizeResponsesTestMode(raw string) string {
+	switch strings.TrimSpace(strings.ToLower(raw)) {
+	case channelModelResponsesTestModeImageGeneration:
+		return channelModelResponsesTestModeImageGeneration
+	default:
+		return channelModelResponsesTestModeText
+	}
 }
 
 func normalizeAudioTestLanguage(raw string) string {
@@ -318,11 +333,11 @@ func buildChannelModelTestResult(row model.ChannelModel, execution channelModelT
 }
 
 func runSingleChannelModelTest(channel *model.Channel, row model.ChannelModel) (model.ChannelTest, channelModelTestExecution) {
-	return runSingleChannelModelTestWithContextAndStream(context.Background(), channel, row, nil, "", imageEditTestInput{})
+	return runSingleChannelModelTestWithContextAndStream(context.Background(), channel, row, nil, "", imageEditTestInput{}, "")
 }
 
 func runSingleChannelModelTestWithContext(ctx context.Context, channel *model.Channel, row model.ChannelModel) (model.ChannelTest, channelModelTestExecution) {
-	return runSingleChannelModelTestWithContextAndStream(ctx, channel, row, nil, "", imageEditTestInput{})
+	return runSingleChannelModelTestWithContextAndStream(ctx, channel, row, nil, "", imageEditTestInput{}, "")
 }
 
 func resolveChannelModelTestRequestURL(baseURL string, path string, adaptor relayadaptor.Adaptor, relayMeta *meta.Meta) string {
@@ -351,11 +366,14 @@ const (
 	channelModelTestKindEmbedding      channelModelTestKind = "embedding"
 )
 
-func resolveChannelModelTestKind(modelType string, endpoint string) channelModelTestKind {
+func resolveChannelModelTestKind(modelType string, endpoint string, responsesTestMode string) channelModelTestKind {
 	switch model.NormalizeRequestedChannelModelEndpoint(endpoint) {
 	case model.ChannelModelEndpointChat, model.ChannelModelEndpointMessages:
 		return channelModelTestKindText
 	case model.ChannelModelEndpointResponses:
+		if normalizeResponsesTestMode(responsesTestMode) == channelModelResponsesTestModeImageGeneration {
+			return channelModelTestKindImageResponses
+		}
 		if strings.EqualFold(strings.TrimSpace(modelType), model.ProviderModelTypeImage) {
 			return channelModelTestKindImageResponses
 		}
@@ -436,7 +454,7 @@ func resolveChannelModelTestEndpointForRow(row model.ChannelModel) (string, erro
 	return "", fmt.Errorf("模型 %s 未声明支持测试端点 %s", strings.TrimSpace(row.Model), endpoint)
 }
 
-func runSingleChannelModelTestWithContextAndStream(ctx context.Context, channel *model.Channel, row model.ChannelModel, requestedStream *bool, requestedAudioLanguage string, imageEditInput imageEditTestInput) (model.ChannelTest, channelModelTestExecution) {
+func runSingleChannelModelTestWithContextAndStream(ctx context.Context, channel *model.Channel, row model.ChannelModel, requestedStream *bool, requestedAudioLanguage string, imageEditInput imageEditTestInput, responsesTestMode string) (model.ChannelTest, channelModelTestExecution) {
 	modelType := resolveSelectionModelType(row)
 	endpoint, endpointErr := resolveChannelModelTestEndpointForRow(row)
 	if endpointErr != nil {
@@ -454,7 +472,7 @@ func runSingleChannelModelTestWithContextAndStream(ctx context.Context, channel 
 		}, execution), execution
 	}
 
-	switch resolveChannelModelTestKind(modelType, endpoint) {
+	switch resolveChannelModelTestKind(modelType, endpoint, responsesTestMode) {
 	case channelModelTestKindText:
 		stream := false
 		if requestedStream != nil {

--- a/internal/admin/controller/channel/model_testing_test.go
+++ b/internal/admin/controller/channel/model_testing_test.go
@@ -397,14 +397,20 @@ func TestRestoreRuntimeDisabledCapabilitiesAfterSuccessfulTests(t *testing.T) {
 }
 
 func TestResolveChannelModelTestKind_UsesEndpointBeforeQwenModelType(t *testing.T) {
-	if got := resolveChannelModelTestKind(adminmodel.ProviderModelTypeImage, adminmodel.ChannelModelEndpointChat); got != channelModelTestKindText {
+	if got := resolveChannelModelTestKind(adminmodel.ProviderModelTypeImage, adminmodel.ChannelModelEndpointChat, ""); got != channelModelTestKindText {
 		t.Fatalf("image+chat test kind = %q, want %q", got, channelModelTestKindText)
 	}
-	if got := resolveChannelModelTestKind(adminmodel.ProviderModelTypeAudio, adminmodel.ChannelModelEndpointChat); got != channelModelTestKindText {
+	if got := resolveChannelModelTestKind(adminmodel.ProviderModelTypeAudio, adminmodel.ChannelModelEndpointChat, ""); got != channelModelTestKindText {
 		t.Fatalf("audio+chat test kind = %q, want %q", got, channelModelTestKindText)
 	}
-	if got := resolveChannelModelTestKind(adminmodel.ProviderModelTypeImage, adminmodel.ChannelModelEndpointResponses); got != channelModelTestKindImageResponses {
+	if got := resolveChannelModelTestKind(adminmodel.ProviderModelTypeImage, adminmodel.ChannelModelEndpointResponses, ""); got != channelModelTestKindImageResponses {
 		t.Fatalf("image+responses test kind = %q, want %q", got, channelModelTestKindImageResponses)
+	}
+	if got := resolveChannelModelTestKind(adminmodel.ProviderModelTypeText, adminmodel.ChannelModelEndpointResponses, ""); got != channelModelTestKindTextResponses {
+		t.Fatalf("text+responses default test kind = %q, want %q", got, channelModelTestKindTextResponses)
+	}
+	if got := resolveChannelModelTestKind(adminmodel.ProviderModelTypeText, adminmodel.ChannelModelEndpointResponses, channelModelResponsesTestModeImageGeneration); got != channelModelTestKindImageResponses {
+		t.Fatalf("text+responses image_generation test kind = %q, want %q", got, channelModelTestKindImageResponses)
 	}
 }
 

--- a/web/src/locales/en/translation.json
+++ b/web/src/locales/en/translation.json
@@ -1016,6 +1016,11 @@
         "settings_button": "Settings",
         "settings_title": "Test Settings",
         "settings_stream": "Stream Test",
+        "responses_test_mode": "Responses Test Mode",
+        "responses_test_mode_options": {
+          "text": "Text response",
+          "image_generation": "Image generation tool"
+        },
         "settings_audio_language": "Speech Test Language",
         "image_edit_source_url": "Image edit test source URL",
         "image_edit_upload": "Upload image edit test source",

--- a/web/src/locales/zh/translation.json
+++ b/web/src/locales/zh/translation.json
@@ -1016,6 +1016,11 @@
         "settings_button": "配置",
         "settings_title": "测试配置",
         "settings_stream": "流式测试",
+        "responses_test_mode": "Responses 测试模式",
+        "responses_test_mode_options": {
+          "text": "文本响应",
+          "image_generation": "生图工具"
+        },
         "settings_audio_language": "语音测试语言",
         "image_edit_source_url": "图片编辑测试原图地址",
         "image_edit_upload": "上传图片编辑测试原图",

--- a/web/src/pages/Channel/ChannelForm.jsx
+++ b/web/src/pages/Channel/ChannelForm.jsx
@@ -1913,6 +1913,7 @@ const ChannelForm = ({ mode = 'auto' } = {}) => {
   const [channelTasks, setChannelTasks] = useState([]);
   const [modelTestError, setModelTestError] = useState('');
   const [audioTestLanguage, setAudioTestLanguage] = useState('zh-CN');
+  const [responsesTestMode, setResponsesTestMode] = useState('text');
   const [imageEditTestURL, setImageEditTestURL] = useState(
     DEFAULT_IMAGE_EDIT_TEST_URL,
   );
@@ -3964,12 +3965,16 @@ const ChannelForm = ({ mode = 'auto' } = {}) => {
       const targetConfigs = visibleChannelModels
         .filter((row) => normalizedTargets.includes(row.model))
         .map((row) => {
+          const endpoint = getEffectiveModelEndpoint(row);
           const targetConfig = {
             model: row.model,
-            endpoint: getEffectiveModelEndpoint(row),
+            endpoint,
           };
           if (supportsModelTestStream(row)) {
             targetConfig.is_stream = !!row.is_stream;
+          }
+          if (endpoint === '/v1/responses') {
+            targetConfig.responses_test_mode = responsesTestMode;
           }
           return targetConfig;
         });
@@ -4030,6 +4035,7 @@ const ChannelForm = ({ mode = 'auto' } = {}) => {
       t,
       visibleChannelModels,
       audioTestLanguage,
+      responsesTestMode,
       imageEditTestURL,
       imageEditTestData,
     ],
@@ -5567,6 +5573,8 @@ const ChannelForm = ({ mode = 'auto' } = {}) => {
                 normalizeChannelModelType={normalizeChannelModelType}
                 audioTestLanguage={audioTestLanguage}
                 setAudioTestLanguage={setAudioTestLanguage}
+                responsesTestMode={responsesTestMode}
+                setResponsesTestMode={setResponsesTestMode}
                 imageEditTestURL={imageEditTestURL}
                 setImageEditTestURL={setImageEditTestURL}
                 imageEditTestFileName={imageEditTestFileName}

--- a/web/src/pages/Channel/components/ChannelDetailTestsTab.jsx
+++ b/web/src/pages/Channel/components/ChannelDetailTestsTab.jsx
@@ -66,6 +66,8 @@ const ChannelDetailTestsTab = ({
   normalizeChannelModelType,
   audioTestLanguage,
   setAudioTestLanguage,
+  responsesTestMode,
+  setResponsesTestMode,
   imageEditTestURL,
   setImageEditTestURL,
   imageEditTestFileName,
@@ -126,6 +128,23 @@ const ChannelDetailTestsTab = ({
         key: 'en-US',
         value: 'en-US',
         text: t('channel.edit.model_tester.audio_language_options.en-US'),
+      },
+    ],
+    [t],
+  );
+  const responsesTestModeOptions = useMemo(
+    () => [
+      {
+        key: 'text',
+        value: 'text',
+        text: t('channel.edit.model_tester.responses_test_mode_options.text'),
+      },
+      {
+        key: 'image_generation',
+        value: 'image_generation',
+        text: t(
+          'channel.edit.model_tester.responses_test_mode_options.image_generation',
+        ),
       },
     ],
     [t],
@@ -248,6 +267,11 @@ const ChannelDetailTestsTab = ({
     }
     return streamCapableRows.every((row) => row?.is_stream !== false);
   }, [streamCapableRows]);
+  const hasResponsesTestRows = useMemo(
+    () =>
+      filteredRows.some((row) => getEffectiveModelEndpoint(row) === '/v1/responses'),
+    [filteredRows, getEffectiveModelEndpoint],
+  );
 
   const resultSummaryByKey = useMemo(() => {
     const summaryMap = new Map();
@@ -416,6 +440,21 @@ const ChannelDetailTestsTab = ({
                       </span>
                     </div>
                   ) : null}
+                  <div className='router-block-gap-xs'>
+                    <label>
+                      {t('channel.edit.model_tester.responses_test_mode')}
+                    </label>
+                    <AppSelect
+                      className='router-section-dropdown router-dropdown-min-170'
+                      disabled={!hasResponsesTestRows}
+                      getPopupContainer={resolvePopupContainer}
+                      options={responsesTestModeOptions}
+                      value={responsesTestMode || 'text'}
+                      onChange={(e, { value }) =>
+                        setResponsesTestMode((value || 'text').toString())
+                      }
+                    />
+                  </div>
                   <div className='router-block-gap-xs'>
                     <label>
                       {t('channel.edit.model_tester.settings_audio_language')}


### PR DESCRIPTION
## Summary
- add a Responses test mode for channel model tests
- support validating /v1/responses image_generation tool capability
- keep the default Responses test mode as text response
- preserve existing image model Responses tests

## Tests
- go test ./internal/admin/controller/channel ./internal/admin/model
- npm run build
- git diff --check