### PR TITLE
feat: add group-scoped request packages and balance lot migration

### DIFF
--- a/docs/扣费逻辑.md
+++ b/docs/扣费逻辑.md
@@ -90,27 +90,31 @@ charge_amount = ceil(raw_charge_amount)
 
 | 模式 | 触发条件 | 扣减对象 | `billing_source` |
 | --- | --- | --- | --- |
-| 套餐模式 | 当前分组有生效套餐，且套餐日额度+套餐应急额度可覆盖预占 | `group_quota_counters` + `user_quota_counters(package_emergency)` | `package` |
-| 余额模式 | 无生效套餐，或套餐额度不足回落 | `users.quota`（并同步余额批次交易） | `balance` |
+| 套餐模式 | 当前分组命中生效套餐，且套餐额度/次数/并发允许 | `group_quota_counters` + `user_quota_counters(package_emergency)`，或 `user_package_usage_counters` | `package` |
+| 余额模式 | 无生效套餐，或套餐额度不足且允许回落 | `users.quota`（并同步余额批次交易） | `balance` |
 
 说明：
 
 - 内部存在 `package_fallback_balance` 场景；日志对外仍归因为 `balance`。
-- 两种模式下若配置令牌限制，令牌额度会同步扣减。
+- YYC 套餐模式下若配置令牌限制，令牌额度会同步扣减。
+- 请求次数套餐模式按 `user_id + group_id` 匹配生效订阅；可用供应商、模型和渠道由分组配置决定，套餐自身不再按供应商或模型匹配。
+- 请求次数套餐命中后按请求数扣减，不扣令牌额度。
 
 ### 4.2 准入与预占
 
 1. 先计算本次预估 `YYC`。
-2. 判断当前分组是否存在生效套餐。
-3. 若有套餐：尝试 `ReservePackageQuota`。
-4. 套餐预占成功则走套餐模式。
-5. 套餐预占因额度不足失败则自动回落余额模式。
-6. 余额模式下检查主余额与令牌额度。
+2. 先按 `user_id + group_id` 尝试请求次数套餐；命中后检查周期剩余次数与并发限制。
+3. 请求次数套餐预占成功则走套餐模式；失败且 `allow_balance_fallback=true` 时回落余额，否则直接拒绝。
+4. 未命中请求次数套餐时，判断当前分组是否存在 YYC 生效套餐。
+5. 若有 YYC 套餐：尝试 `ReservePackageQuota`。
+6. YYC 套餐预占成功则走套餐模式；额度不足时自动回落余额模式。
+7. 余额模式下检查主余额与令牌额度。
 
 ### 4.3 结算与回滚
 
 1. 请求成功：
-- 套餐模式先结算日额度，再结算套餐应急额度。
+- YYC 套餐模式先结算日额度，再结算套餐应急额度。
+- 请求次数套餐模式结算 1 次请求，失败或中断时释放预占。
 - 余额模式扣减 `users.quota` 并写余额交易。
 2. 请求失败：
 - 释放预占，并归还预扣余额/令牌。
@@ -120,14 +124,16 @@ charge_amount = ceil(raw_charge_amount)
 1. 准入阶段按“预估 `YYC`”预占（避免并发超扣）。
 2. 结算阶段按真实 usage 重算 `YYC`，并对“预估 - 实际”做差额回补或补扣。
 3. 余额模式在“主余额远大于预估值”（`user_quota > 100 × preConsumedQuota`）时，会跳过数据库层预扣，最终按实耗落账。
-4. 套餐模式只要预占成功，就始终先在套餐计数器结算；套餐不足才会在准入阶段回落到余额模式。
+4. YYC 套餐模式只要预占成功，就始终先在套餐计数器结算；套餐不足才会在准入阶段回落到余额模式。
+5. 请求次数套餐按请求维度计数，不随实际 token/图片/视频用量变化调整次数。
 
 ## 5. 周期与计数器口径
 
 1. 分组套餐日额度：`group_quota_counters(counter_type=daily)`，按自然日。
 2. 套餐应急额度：`user_quota_counters(counter_type=package_emergency)`，按自然月。
-3. 周期边界时区：`quota_reset_timezone`，空值回落 `Asia/Shanghai`。
-4. 分组日额度策略来自“当前分组生效套餐”；无生效套餐时该分组视图口径为 unlimited（`limit=0`）。
+3. 请求次数套餐：`user_package_usage_counters(metric=request_count)`，周期由套餐 `period_type` 决定，常用月周期。
+4. 周期边界时区：`quota_reset_timezone`，空值回落 `Asia/Shanghai`。
+5. 分组日额度策略来自“当前分组生效 YYC 套餐”；无生效套餐时该分组视图口径为 unlimited（`limit=0`）。
 
 ## 6. 余额批次口径
 
@@ -169,7 +175,7 @@ charge_amount = ceil(raw_charge_amount)
 ## 9. 当前边界（代码现状）
 
 1. 日志 `billing_source` 当前只落两类：`package`、`balance`（不落 `package_fallback_balance`）。
-2. 套餐准入基于 `ReservePackageQuota`（分组日额度 + 套餐应急额度），余额准入基于主余额与令牌额度。
+2. 请求次数套餐准入基于 `ReserveRequestPackage`（周期次数 + 并发预占）；YYC 套餐准入基于 `ReservePackageQuota`（分组日额度 + 套餐应急额度）；余额准入基于主余额与令牌额度。
 3. 计价与记账保留双快照：法币金额（`billing_*_amount`）与 `YYC`（`billing_charge_amount`）。
 
 ## 10. 词元计算
@@ -187,7 +193,8 @@ charge_amount = ceil(raw_charge_amount)
 ## 11. 代码锚点
 
 - 模式判定与回落：`internal/relay/controller/billing_mode.go`
-- 套餐预占/释放/结算：`internal/admin/model/user_quota_counter.go`
+- YYC 套餐预占/释放/结算：`internal/admin/model/user_quota_counter.go`
+- 请求次数套餐预占/释放/结算：`internal/admin/model/user_package_usage_counter.go`
 - 分组日额度：`internal/admin/model/group_quota_daily_counter.go`
 - 余额批次：`internal/admin/model/user_balance_lot.go`
 - 消费后记账：`internal/relay/billing/billing.go`

--- a/docs/接口文档.md
+++ b/docs/接口文档.md
@@ -192,7 +192,9 @@ Authorization: Bearer <JWT>
 > `GET /api/v1/public/user/topup/orders/:id` 返回单条充值订单详情。
 > `POST /api/v1/public/user/topup/orders/:id/refresh` 用于主动查单并补推进订单状态。
 > `POST /api/v1/public/user/topup/orders/:id/cancel` 用于取消当前用户自己的未完成订单。
-> `GET /api/v1/public/user/packages` 返回数组对象 `data`，每项至少包含：`id`、`name`、`description`、`group_id`、`group_name`、`sale_price`、`sale_currency`、`duration_days`、`daily_quota_limit`、`package_emergency_quota_limit`。
+> `GET /api/v1/public/user/package/subscription` 返回当前用户生效套餐状态：`has_active_subscription`、兼容字段 `subscription`、完整列表 `subscriptions`。请求次数套餐会在订阅对象内返回 `usage`，包含 `period_key`、`limit_amount`、`consumed_amount`、`reserved_amount`、`remaining_amount`。
+> `GET /api/v1/public/user/packages` 返回数组对象 `data`，每项至少包含：`id`、`name`、`description`、`group_id`、`group_name`、`package_type`、`quota_metric`、`period_type`、`period_limit`、`max_concurrency_per_user`、`max_concurrency_per_package`、`allow_balance_fallback`、`sale_price`、`sale_currency`、`duration_days`、`daily_quota_limit`、`package_emergency_quota_limit`。
+> 套餐的可用供应商、模型和渠道由 `group_id` 对应分组决定；套餐自身只定义商业权益与周期/并发/回落规则，不单独维护供应商或模型范围。
 > `POST /api/v1/public/user/topup/orders` 当前返回对象 `data`，字段包括：`id`、`transaction_id`、`status`、`redirect_url`、`created_at`。
 > `POST /api/v1/public/user/topup` 当前返回对象 `data`，字段包括：`redeemed_amount`、`before_balance_amount`、`after_balance_amount`、`redemption_id`、`redemption_name`、`group_id`、`group_name`、`face_value_amount`、`face_value_unit`、`redeemed_at`、`credit_expires_at`。
 > 管理台展示策略：业务流水“充值”与“兑换”为独立页面；充值列表不展示关联兑换列，兑换列表不展示充值订单列。
@@ -407,6 +409,7 @@ Authorization: Bearer <TOKEN>
 ### 6.2) `/v1/models` 输出边界
 
 > `/v1/models` 返回的是当前请求上下文可用模型，而不是 Router 全量支持模型。
+> 具体口径是“当前请求令牌支持的模型”；当令牌未声明模型范围时，再回落到当前用户分组可见模型范围。
 > 当请求携带用户令牌且令牌声明了模型范围时，优先返回该令牌允许的模型；当令牌未声明模型范围时，再回落到用户分组可见模型范围。
 
 ### 7) 个人日志（JWT）
@@ -491,7 +494,7 @@ Authorization: Bearer <TOKEN>
 - `GET    /api/v1/admin/user/search`
 - 用户搜索支持：用户名/邮箱/显示名/ID，以及钱包地址前缀搜索（`keyword%`）
 - `GET    /api/v1/admin/user/:id`
-- `GET    /api/v1/admin/user/:id/package/subscription`（读取用户当前生效套餐，返回 `has_active_subscription` 与 `subscription`）
+- `GET    /api/v1/admin/user/:id/package/subscription`（读取用户当前生效套餐，返回 `has_active_subscription`、兼容字段 `subscription` 与完整列表 `subscriptions`）
 - `GET    /api/v1/admin/user/:id/redemptions`（读取用户最近兑换记录）
 - `GET    /api/v1/admin/user/:id/quota/summary`
 - `GET    /api/v1/admin/user/:id/topup/balance/lots`（用户余额批次）
@@ -1084,6 +1087,14 @@ Authorization: Bearer <TOKEN>
 - `PUT    /api/v1/admin/package`（更新套餐）
 - `DELETE /api/v1/admin/package/:id`（删除套餐，存在生效订阅时会拒绝）
 - `POST   /api/v1/admin/package/:id/assign`（为指定用户开通套餐，参数：`user_id`，可选 `start_at`）
+
+套餐字段口径：
+
+- `group_id` 是套餐可用范围的唯一模型/渠道入口；供应商、模型和渠道能力由分组配置决定。
+- `package_type=yyc_quota` 表示按 `YYC` 扣减的传统套餐；`quota_metric=yyc`，周期字段通常为 `period_type=daily`。
+- `package_type=request_quota` 表示按请求次数扣减的套餐；`quota_metric=request_count`，通常使用 `period_type=monthly` 与 `period_limit` 表示每周期请求次数，例如每月 25000 次。
+- `max_concurrency_per_user` 限制单用户同一请求次数套餐的并发预占数；`max_concurrency_per_package` 限制该套餐整体并发预占数。
+- `allow_balance_fallback=true` 时，请求次数套餐额度或并发不可用后可回落余额；否则直接拒绝。
 
 ### 8) 系统配置（Root）
 

--- a/internal/admin/controller/plan/handler.go
+++ b/internal/admin/controller/plan/handler.go
@@ -28,6 +28,13 @@ type upsertServicePackageRequest struct {
 	Name                       *string  `json:"name"`
 	Description                *string  `json:"description"`
 	GroupID                    *string  `json:"group_id"`
+	PackageType                *string  `json:"package_type"`
+	QuotaMetric                *string  `json:"quota_metric"`
+	PeriodType                 *string  `json:"period_type"`
+	PeriodLimit                *int64   `json:"period_limit"`
+	MaxConcurrencyPerUser      *int     `json:"max_concurrency_per_user"`
+	MaxConcurrencyPerPackage   *int     `json:"max_concurrency_per_package"`
+	AllowBalanceFallback       *bool    `json:"allow_balance_fallback"`
 	VisibilityScope            *string  `json:"visibility_scope"`
 	VisibleUserIDs             []string `json:"visible_user_ids"`
 	SalePrice                  *float64 `json:"sale_price"`
@@ -181,6 +188,14 @@ func CreatePackage(c *gin.Context) {
 		Name:                       optionalStringValue(req.Name, ""),
 		Description:                optionalStringValue(req.Description, ""),
 		GroupID:                    optionalStringValue(req.GroupID, ""),
+		PackageType:                optionalStringValue(req.PackageType, ""),
+		ScopeType:                  model.ServicePackageScopeAll,
+		QuotaMetric:                optionalStringValue(req.QuotaMetric, ""),
+		PeriodType:                 optionalStringValue(req.PeriodType, ""),
+		PeriodLimit:                optionalInt64Value(req.PeriodLimit, 0),
+		MaxConcurrencyPerUser:      optionalIntValue(req.MaxConcurrencyPerUser, 0),
+		MaxConcurrencyPerPackage:   optionalIntValue(req.MaxConcurrencyPerPackage, 0),
+		AllowBalanceFallback:       optionalBoolValue(req.AllowBalanceFallback, false),
 		VisibilityScope:            optionalStringValue(req.VisibilityScope, model.ServicePackageVisibilityScopeAll),
 		VisibleUserIDs:             req.VisibleUserIDs,
 		SalePrice:                  optionalFloat64Value(req.SalePrice, 0),
@@ -242,6 +257,14 @@ func UpdatePackage(c *gin.Context) {
 		Name:                       optionalStringValue(req.Name, current.Name),
 		Description:                optionalStringValue(req.Description, current.Description),
 		GroupID:                    optionalStringValue(req.GroupID, current.GroupID),
+		PackageType:                optionalStringValue(req.PackageType, current.PackageType),
+		ScopeType:                  model.ServicePackageScopeAll,
+		QuotaMetric:                optionalStringValue(req.QuotaMetric, current.QuotaMetric),
+		PeriodType:                 optionalStringValue(req.PeriodType, current.PeriodType),
+		PeriodLimit:                optionalInt64Value(req.PeriodLimit, current.PeriodLimit),
+		MaxConcurrencyPerUser:      optionalIntValue(req.MaxConcurrencyPerUser, current.MaxConcurrencyPerUser),
+		MaxConcurrencyPerPackage:   optionalIntValue(req.MaxConcurrencyPerPackage, current.MaxConcurrencyPerPackage),
+		AllowBalanceFallback:       optionalBoolValue(req.AllowBalanceFallback, current.AllowBalanceFallback),
 		VisibilityScope:            optionalStringValue(req.VisibilityScope, current.VisibilityScope),
 		VisibleUserIDs:             req.VisibleUserIDs,
 		SalePrice:                  optionalFloat64Value(req.SalePrice, current.SalePrice),

--- a/internal/admin/controller/user/handler.go
+++ b/internal/admin/controller/user/handler.go
@@ -41,24 +41,49 @@ type LoginRequest struct {
 }
 
 type activeUserPackageSubscriptionView struct {
-	Id                         string `json:"id"`
-	UserID                     string `json:"user_id"`
-	PackageID                  string `json:"package_id"`
-	PackageName                string `json:"package_name"`
-	GroupID                    string `json:"group_id"`
-	GroupName                  string `json:"group_name,omitempty"`
-	DailyQuotaLimit            int64  `json:"daily_quota_limit"`
-	PackageEmergencyQuotaLimit int64  `json:"package_emergency_quota_limit"`
-	QuotaResetTimezone         string `json:"quota_reset_timezone"`
-	StartedAt                  int64  `json:"started_at"`
-	ExpiresAt                  int64  `json:"expires_at"`
-	Status                     int    `json:"status"`
-	Source                     string `json:"source,omitempty"`
+	Id                         string                      `json:"id"`
+	UserID                     string                      `json:"user_id"`
+	PackageID                  string                      `json:"package_id"`
+	PackageName                string                      `json:"package_name"`
+	GroupID                    string                      `json:"group_id"`
+	GroupName                  string                      `json:"group_name,omitempty"`
+	PackageType                string                      `json:"package_type"`
+	ScopeType                  string                      `json:"scope_type"`
+	ScopeProvider              string                      `json:"scope_provider"`
+	ScopeModel                 string                      `json:"scope_model"`
+	ScopeEndpoint              string                      `json:"scope_endpoint"`
+	QuotaMetric                string                      `json:"quota_metric"`
+	PeriodType                 string                      `json:"period_type"`
+	PeriodLimit                int64                       `json:"period_limit"`
+	MaxConcurrencyPerUser      int                         `json:"max_concurrency_per_user"`
+	MaxConcurrencyPerPackage   int                         `json:"max_concurrency_per_package"`
+	AllowBalanceFallback       bool                        `json:"allow_balance_fallback"`
+	DailyQuotaLimit            int64                       `json:"daily_quota_limit"`
+	PackageEmergencyQuotaLimit int64                       `json:"package_emergency_quota_limit"`
+	QuotaResetTimezone         string                      `json:"quota_reset_timezone"`
+	StartedAt                  int64                       `json:"started_at"`
+	ExpiresAt                  int64                       `json:"expires_at"`
+	Status                     int                         `json:"status"`
+	Source                     string                      `json:"source,omitempty"`
+	Usage                      *activeUserPackageUsageView `json:"usage,omitempty"`
+}
+
+type activeUserPackageUsageView struct {
+	Metric          string `json:"metric"`
+	PeriodType      string `json:"period_type"`
+	PeriodKey       string `json:"period_key"`
+	LimitAmount     int64  `json:"limit_amount"`
+	ConsumedAmount  int64  `json:"consumed_amount"`
+	ReservedAmount  int64  `json:"reserved_amount"`
+	RemainingAmount int64  `json:"remaining_amount"`
+	Unlimited       bool   `json:"unlimited"`
+	UpdatedAt       int64  `json:"updated_at"`
 }
 
 type activeUserPackageSubscriptionPayload struct {
-	HasActiveSubscription bool                               `json:"has_active_subscription"`
-	Subscription          *activeUserPackageSubscriptionView `json:"subscription,omitempty"`
+	HasActiveSubscription bool                                 `json:"has_active_subscription"`
+	Subscription          *activeUserPackageSubscriptionView   `json:"subscription,omitempty"`
+	Subscriptions         []*activeUserPackageSubscriptionView `json:"subscriptions,omitempty"`
 }
 
 type userRecentRedemptionsPayload struct {
@@ -144,7 +169,21 @@ func requesterCanReadUser(c *gin.Context, targetUser *model.User) bool {
 	return c.GetInt(ctxkey.Role) >= model.EffectiveRole(targetUser)
 }
 
-func buildActiveUserPackageSubscriptionView(subscription model.UserPackageSubscription) *activeUserPackageSubscriptionView {
+func buildActiveUserPackageUsageView(snapshot model.RequestPackageUsageSnapshot) *activeUserPackageUsageView {
+	return &activeUserPackageUsageView{
+		Metric:          strings.TrimSpace(snapshot.Metric),
+		PeriodType:      strings.TrimSpace(snapshot.PeriodType),
+		PeriodKey:       strings.TrimSpace(snapshot.PeriodKey),
+		LimitAmount:     snapshot.LimitAmount,
+		ConsumedAmount:  snapshot.ConsumedAmount,
+		ReservedAmount:  snapshot.ReservedAmount,
+		RemainingAmount: snapshot.RemainingAmount,
+		Unlimited:       snapshot.Unlimited,
+		UpdatedAt:       snapshot.UpdatedAt,
+	}
+}
+
+func buildActiveUserPackageSubscriptionView(subscription model.UserPackageSubscription) (*activeUserPackageSubscriptionView, error) {
 	groupID := strings.TrimSpace(subscription.GroupID)
 	groupName := ""
 	if groupID != "" {
@@ -158,6 +197,14 @@ func buildActiveUserPackageSubscriptionView(subscription model.UserPackageSubscr
 			source = strings.TrimSpace(servicePackage.Source)
 		}
 	}
+	var usage *activeUserPackageUsageView
+	if strings.TrimSpace(subscription.QuotaMetric) == model.ServicePackageQuotaMetricRequestCount {
+		snapshot, err := model.GetRequestPackageUsageSnapshot(subscription)
+		if err != nil {
+			return nil, err
+		}
+		usage = buildActiveUserPackageUsageView(snapshot)
+	}
 	return &activeUserPackageSubscriptionView{
 		Id:                         strings.TrimSpace(subscription.Id),
 		UserID:                     strings.TrimSpace(subscription.UserID),
@@ -165,6 +212,17 @@ func buildActiveUserPackageSubscriptionView(subscription model.UserPackageSubscr
 		PackageName:                strings.TrimSpace(subscription.PackageName),
 		GroupID:                    groupID,
 		GroupName:                  groupName,
+		PackageType:                strings.TrimSpace(subscription.PackageType),
+		ScopeType:                  strings.TrimSpace(subscription.ScopeType),
+		ScopeProvider:              strings.TrimSpace(subscription.ScopeProvider),
+		ScopeModel:                 strings.TrimSpace(subscription.ScopeModel),
+		ScopeEndpoint:              strings.TrimSpace(subscription.ScopeEndpoint),
+		QuotaMetric:                strings.TrimSpace(subscription.QuotaMetric),
+		PeriodType:                 strings.TrimSpace(subscription.PeriodType),
+		PeriodLimit:                subscription.PeriodLimit,
+		MaxConcurrencyPerUser:      subscription.MaxConcurrencyPerUser,
+		MaxConcurrencyPerPackage:   subscription.MaxConcurrencyPerPackage,
+		AllowBalanceFallback:       subscription.AllowBalanceFallback,
 		DailyQuotaLimit:            subscription.DailyQuotaLimit,
 		PackageEmergencyQuotaLimit: subscription.PackageEmergencyQuotaLimit,
 		QuotaResetTimezone:         strings.TrimSpace(subscription.QuotaResetTimezone),
@@ -172,22 +230,48 @@ func buildActiveUserPackageSubscriptionView(subscription model.UserPackageSubscr
 		ExpiresAt:                  subscription.ExpiresAt,
 		Status:                     subscription.Status,
 		Source:                     source,
+		Usage:                      usage,
+	}, nil
+}
+
+func selectPrimaryActiveUserPackageSubscriptionView(views []*activeUserPackageSubscriptionView) *activeUserPackageSubscriptionView {
+	for _, view := range views {
+		if view == nil {
+			continue
+		}
+		if strings.TrimSpace(view.PackageType) == model.ServicePackageTypeYYCQuota &&
+			strings.TrimSpace(view.QuotaMetric) == model.ServicePackageQuotaMetricYYC {
+			return view
+		}
 	}
+	if len(views) == 0 {
+		return nil
+	}
+	return views[0]
 }
 
 func loadActiveUserPackageSubscriptionPayload(userID string) (activeUserPackageSubscriptionPayload, error) {
-	subscription, err := model.GetActiveUserPackageSubscription(strings.TrimSpace(userID))
+	subscriptions, err := model.ListActiveUserPackageSubscriptions(strings.TrimSpace(userID))
 	if err != nil {
-		if errors.Is(err, gorm.ErrRecordNotFound) {
-			return activeUserPackageSubscriptionPayload{
-				HasActiveSubscription: false,
-			}, nil
-		}
 		return activeUserPackageSubscriptionPayload{}, err
+	}
+	if len(subscriptions) == 0 {
+		return activeUserPackageSubscriptionPayload{
+			HasActiveSubscription: false,
+		}, nil
+	}
+	views := make([]*activeUserPackageSubscriptionView, 0, len(subscriptions))
+	for _, subscription := range subscriptions {
+		view, err := buildActiveUserPackageSubscriptionView(subscription)
+		if err != nil {
+			return activeUserPackageSubscriptionPayload{}, err
+		}
+		views = append(views, view)
 	}
 	return activeUserPackageSubscriptionPayload{
 		HasActiveSubscription: true,
-		Subscription:          buildActiveUserPackageSubscriptionView(subscription),
+		Subscription:          selectPrimaryActiveUserPackageSubscriptionView(views),
+		Subscriptions:         views,
 	}, nil
 }
 

--- a/internal/admin/model/group_quota_daily_counter.go
+++ b/internal/admin/model/group_quota_daily_counter.go
@@ -96,7 +96,7 @@ func resolveEffectiveGroupDailyQuotaPolicyWithDB(db *gorm.DB, groupID string, us
 	if normalizedUserID == "" {
 		return effective, nil
 	}
-	subscription, err := getActiveUserPackageSubscriptionForGroupWithDB(db, normalizedUserID, normalizedGroupID)
+	subscription, err := getActiveYYCUserPackageSubscriptionForGroupWithDB(db, normalizedUserID, normalizedGroupID)
 	if err != nil {
 		if errors.Is(err, gorm.ErrRecordNotFound) {
 			return effective, nil

--- a/internal/admin/model/migration_baseline.go
+++ b/internal/admin/model/migration_baseline.go
@@ -43,6 +43,7 @@ func runMainBaselineMigrationWithDB(tx *gorm.DB) error {
 		&ServicePackage{},
 		&ServicePackageVisibleUser{},
 		&UserPackageSubscription{},
+		&UserPackageUsageCounter{},
 		&GroupQuotaCounter{},
 		&UserQuotaCounter{},
 		&Log{},

--- a/internal/admin/model/migration_runner.go
+++ b/internal/admin/model/migration_runner.go
@@ -1574,8 +1574,175 @@ func runMainVersionedMigrations(db *gorm.DB) error {
 				return ensureUserWalletAddressCaseInsensitiveUniqueWithDB(tx)
 			},
 		},
+		{
+			Version:     "202606271430_service_package_scope_usage_counters",
+			Description: "extend service packages with request quota, period, concurrency, and usage counters",
+			Up: func(tx *gorm.DB) error {
+				return migrateServicePackageScopeAndUsageCountersWithDB(tx)
+			},
+		},
 	}
 	return runVersionedMigrations(db, migrationScopeMain, migrations)
+}
+
+func migrateServicePackageScopeAndUsageCountersWithDB(db *gorm.DB) error {
+	if db == nil {
+		return fmt.Errorf("database handle is nil")
+	}
+	if err := db.AutoMigrate(&ServicePackage{}, &UserPackageSubscription{}, &UserPackageUsageCounter{}); err != nil {
+		return err
+	}
+	if err := backfillServicePackageScopeFieldsWithDB(db); err != nil {
+		return err
+	}
+	return backfillUserPackageSubscriptionScopeFieldsWithDB(db)
+}
+
+func backfillServicePackageScopeFieldsWithDB(db *gorm.DB) error {
+	if err := db.Exec(`
+		UPDATE service_packages
+		SET
+			package_type = CASE
+				WHEN COALESCE(TRIM(package_type), '') = '' THEN ?
+				ELSE package_type
+			END,
+			scope_type = ?,
+			scope_provider = '',
+			scope_model = '',
+			scope_endpoint = '',
+			quota_metric = CASE
+				WHEN COALESCE(TRIM(quota_metric), '') = '' THEN ?
+				ELSE quota_metric
+			END,
+			period_type = CASE
+				WHEN COALESCE(TRIM(period_type), '') = '' THEN ?
+				ELSE period_type
+			END,
+			period_limit = CASE
+				WHEN COALESCE(period_limit, 0) = 0 AND COALESCE(daily_quota_limit, 0) > 0 THEN daily_quota_limit
+				ELSE COALESCE(period_limit, 0)
+			END,
+			max_concurrency_per_user = CASE
+				WHEN COALESCE(max_concurrency_per_user, 0) < 0 THEN 0
+				ELSE COALESCE(max_concurrency_per_user, 0)
+			END,
+			max_concurrency_per_package = CASE
+				WHEN COALESCE(max_concurrency_per_package, 0) < 0 THEN 0
+				ELSE COALESCE(max_concurrency_per_package, 0)
+			END,
+			allow_balance_fallback = CASE
+				WHEN COALESCE(TRIM(package_type), '') IN ('', ?) AND COALESCE(TRIM(quota_metric), '') IN ('', ?) THEN TRUE
+				ELSE COALESCE(allow_balance_fallback, FALSE)
+			END
+	`,
+		ServicePackageTypeYYCQuota,
+		ServicePackageScopeAll,
+		ServicePackageQuotaMetricYYC,
+		ServicePackagePeriodDaily,
+		ServicePackageTypeYYCQuota,
+		ServicePackageQuotaMetricYYC,
+	).Error; err != nil {
+		return err
+	}
+	return nil
+}
+
+func backfillUserPackageSubscriptionScopeFieldsWithDB(db *gorm.DB) error {
+	if err := db.Exec(`
+		UPDATE user_package_subscriptions AS s
+		SET
+			package_type = CASE
+				WHEN COALESCE(TRIM(s.package_type), '') = '' THEN COALESCE(NULLIF(TRIM(p.package_type), ''), ?)
+				ELSE s.package_type
+			END,
+			scope_type = ?,
+			scope_provider = '',
+			scope_model = '',
+			scope_endpoint = '',
+			quota_metric = CASE
+				WHEN COALESCE(TRIM(s.quota_metric), '') = '' THEN COALESCE(NULLIF(TRIM(p.quota_metric), ''), ?)
+				ELSE s.quota_metric
+			END,
+			period_type = CASE
+				WHEN COALESCE(TRIM(s.period_type), '') = '' THEN COALESCE(NULLIF(TRIM(p.period_type), ''), ?)
+				ELSE s.period_type
+			END,
+			period_limit = CASE
+				WHEN COALESCE(s.period_limit, 0) = 0 AND COALESCE(p.period_limit, 0) > 0 THEN p.period_limit
+				WHEN COALESCE(s.period_limit, 0) = 0 AND COALESCE(s.daily_quota_limit, 0) > 0 THEN s.daily_quota_limit
+				ELSE COALESCE(s.period_limit, 0)
+			END,
+			max_concurrency_per_user = CASE
+				WHEN COALESCE(s.max_concurrency_per_user, 0) = 0 AND COALESCE(p.max_concurrency_per_user, 0) < 0 THEN 0
+				WHEN COALESCE(s.max_concurrency_per_user, 0) = 0 THEN COALESCE(p.max_concurrency_per_user, 0)
+				WHEN s.max_concurrency_per_user < 0 THEN 0
+				ELSE s.max_concurrency_per_user
+			END,
+			max_concurrency_per_package = CASE
+				WHEN COALESCE(s.max_concurrency_per_package, 0) = 0 AND COALESCE(p.max_concurrency_per_package, 0) < 0 THEN 0
+				WHEN COALESCE(s.max_concurrency_per_package, 0) = 0 THEN COALESCE(p.max_concurrency_per_package, 0)
+				WHEN s.max_concurrency_per_package < 0 THEN 0
+				ELSE s.max_concurrency_per_package
+			END,
+			allow_balance_fallback = CASE
+				WHEN COALESCE(TRIM(s.package_type), '') IN ('', ?) AND COALESCE(TRIM(s.quota_metric), '') IN ('', ?) THEN TRUE
+				ELSE COALESCE(s.allow_balance_fallback, p.allow_balance_fallback, FALSE)
+			END
+		FROM service_packages p
+		WHERE p.id = s.package_id
+	`,
+		ServicePackageTypeYYCQuota,
+		ServicePackageScopeAll,
+		ServicePackageQuotaMetricYYC,
+		ServicePackagePeriodDaily,
+		ServicePackageTypeYYCQuota,
+		ServicePackageQuotaMetricYYC,
+	).Error; err != nil {
+		return err
+	}
+	return db.Exec(`
+		UPDATE user_package_subscriptions
+		SET
+			package_type = CASE
+				WHEN COALESCE(TRIM(package_type), '') = '' THEN ?
+				ELSE package_type
+			END,
+			scope_type = ?,
+			scope_provider = '',
+			scope_model = '',
+			scope_endpoint = '',
+			quota_metric = CASE
+				WHEN COALESCE(TRIM(quota_metric), '') = '' THEN ?
+				ELSE quota_metric
+			END,
+			period_type = CASE
+				WHEN COALESCE(TRIM(period_type), '') = '' THEN ?
+				ELSE period_type
+			END,
+			period_limit = CASE
+				WHEN COALESCE(period_limit, 0) = 0 AND COALESCE(daily_quota_limit, 0) > 0 THEN daily_quota_limit
+				ELSE COALESCE(period_limit, 0)
+			END,
+			max_concurrency_per_user = CASE
+				WHEN COALESCE(max_concurrency_per_user, 0) < 0 THEN 0
+				ELSE COALESCE(max_concurrency_per_user, 0)
+			END,
+			max_concurrency_per_package = CASE
+				WHEN COALESCE(max_concurrency_per_package, 0) < 0 THEN 0
+				ELSE COALESCE(max_concurrency_per_package, 0)
+			END,
+			allow_balance_fallback = CASE
+				WHEN COALESCE(TRIM(package_type), '') IN ('', ?) AND COALESCE(TRIM(quota_metric), '') IN ('', ?) THEN TRUE
+				ELSE COALESCE(allow_balance_fallback, FALSE)
+			END
+	`,
+		ServicePackageTypeYYCQuota,
+		ServicePackageScopeAll,
+		ServicePackageQuotaMetricYYC,
+		ServicePackagePeriodDaily,
+		ServicePackageTypeYYCQuota,
+		ServicePackageQuotaMetricYYC,
+	).Error
 }
 
 func ensureProcurementCostTablesWithDB(db *gorm.DB) error {

--- a/internal/admin/model/migration_runner.go
+++ b/internal/admin/model/migration_runner.go
@@ -1506,6 +1506,13 @@ func runMainVersionedMigrations(db *gorm.DB) error {
 			},
 		},
 		{
+			Version:     "202606271700_user_balance_lot_transaction_amount_columns",
+			Description: "ensure user balance lot transaction amount columns exist and backfill legacy yyc columns",
+			Up: func(tx *gorm.DB) error {
+				return ensureUserBalanceLotTransactionAmountColumnsWithDB(tx)
+			},
+		},
+		{
 			Version:     "202606231030_openai_realtime_model_tags",
 			Description: "refresh openai provider migration rows to mark realtime voice models with realtime capability tags",
 			Up: func(tx *gorm.DB) error {

--- a/internal/admin/model/service_package.go
+++ b/internal/admin/model/service_package.go
@@ -19,11 +19,39 @@ const (
 	ServicePackageVisibilityScopeUser = "partial_users"
 )
 
+const (
+	ServicePackageTypeYYCQuota     = "yyc_quota"
+	ServicePackageTypeRequestQuota = "request_quota"
+
+	ServicePackageScopeAll = "all"
+
+	ServicePackageQuotaMetricYYC          = "yyc"
+	ServicePackageQuotaMetricRequestCount = "request_count"
+
+	ServicePackagePeriodNone         = "none"
+	ServicePackagePeriodDaily        = "daily"
+	ServicePackagePeriodMonthly      = "monthly"
+	ServicePackagePeriodPackageTotal = "package_total"
+)
+
+const servicePackageDefaultScopeType = ServicePackageScopeAll
+
 type ServicePackage struct {
 	Id                         string                             `json:"id" gorm:"primaryKey;type:char(36)"`
 	Name                       string                             `json:"name" gorm:"type:varchar(64);not null;uniqueIndex"`
 	Description                string                             `json:"description" gorm:"type:varchar(255);default:''"`
 	GroupID                    string                             `json:"group_id" gorm:"type:char(36);not null;index"`
+	PackageType                string                             `json:"package_type" gorm:"type:varchar(32);not null;default:'yyc_quota';index"`
+	ScopeType                  string                             `json:"scope_type" gorm:"type:varchar(32);not null;default:'all';index"`
+	ScopeProvider              string                             `json:"scope_provider" gorm:"type:varchar(64);not null;default:'';index"`
+	ScopeModel                 string                             `json:"scope_model" gorm:"type:varchar(191);not null;default:'';index"`
+	ScopeEndpoint              string                             `json:"scope_endpoint" gorm:"type:varchar(191);not null;default:''"`
+	QuotaMetric                string                             `json:"quota_metric" gorm:"type:varchar(32);not null;default:'yyc';index"`
+	PeriodType                 string                             `json:"period_type" gorm:"type:varchar(32);not null;default:'daily';index"`
+	PeriodLimit                int64                              `json:"period_limit" gorm:"type:bigint;not null;default:0"`
+	MaxConcurrencyPerUser      int                                `json:"max_concurrency_per_user" gorm:"type:int;not null;default:0"`
+	MaxConcurrencyPerPackage   int                                `json:"max_concurrency_per_package" gorm:"type:int;not null;default:0"`
+	AllowBalanceFallback       bool                               `json:"allow_balance_fallback" gorm:"not null;default:false"`
 	VisibilityScope            string                             `json:"visibility_scope" gorm:"type:varchar(32);not null;default:'all';index"`
 	SalePrice                  float64                            `json:"sale_price" gorm:"type:decimal(10,2);not null;default:0"`
 	SaleCurrency               string                             `json:"sale_currency" gorm:"type:varchar(16);not null;default:'CNY'"`
@@ -89,6 +117,145 @@ func normalizeServicePackageVisibilityScope(value string) string {
 	default:
 		return ServicePackageVisibilityScopeAll
 	}
+}
+
+func normalizeServicePackagePackageType(value string, quotaMetric string) string {
+	normalized := strings.TrimSpace(strings.ToLower(value))
+	switch normalized {
+	case ServicePackageTypeYYCQuota, ServicePackageTypeRequestQuota:
+		return normalized
+	}
+	switch strings.TrimSpace(strings.ToLower(quotaMetric)) {
+	case ServicePackageQuotaMetricRequestCount:
+		return ServicePackageTypeRequestQuota
+	default:
+		return ServicePackageTypeYYCQuota
+	}
+}
+
+func normalizeServicePackageQuotaMetric(value string, packageType string) string {
+	normalized := strings.TrimSpace(strings.ToLower(value))
+	switch normalized {
+	case ServicePackageQuotaMetricYYC, ServicePackageQuotaMetricRequestCount:
+		return normalized
+	}
+	if packageType == ServicePackageTypeRequestQuota {
+		return ServicePackageQuotaMetricRequestCount
+	}
+	return ServicePackageQuotaMetricYYC
+}
+
+func normalizeServicePackageScopeFields(scopeType string, provider string, model string, endpoint string) (string, string, string, string) {
+	return servicePackageDefaultScopeType, "", "", ""
+}
+
+func normalizeServicePackagePeriodType(value string, quotaMetric string) string {
+	normalized := strings.TrimSpace(strings.ToLower(value))
+	switch normalized {
+	case ServicePackagePeriodNone, ServicePackagePeriodDaily, ServicePackagePeriodMonthly, ServicePackagePeriodPackageTotal:
+		return normalized
+	}
+	if quotaMetric == ServicePackageQuotaMetricRequestCount {
+		return ServicePackagePeriodMonthly
+	}
+	return ServicePackagePeriodDaily
+}
+
+func normalizeServicePackagePeriodLimit(value int64, quotaMetric string, periodType string, dailyQuotaLimit int64) int64 {
+	if value > 0 {
+		return value
+	}
+	if quotaMetric == ServicePackageQuotaMetricYYC && periodType == ServicePackagePeriodDaily {
+		return normalizeServicePackageDailyQuotaLimit(dailyQuotaLimit)
+	}
+	return 0
+}
+
+func normalizeServicePackageConcurrencyLimit(value int) int {
+	if value < 0 {
+		return 0
+	}
+	return value
+}
+
+func DefaultServicePackageAllowBalanceFallback(packageType string, quotaMetric string) bool {
+	return packageType == ServicePackageTypeYYCQuota && quotaMetric == ServicePackageQuotaMetricYYC
+}
+
+func normalizeServicePackageAllowBalanceFallback(value bool, rawPackageType string, rawQuotaMetric string, packageType string, quotaMetric string) bool {
+	if value {
+		return true
+	}
+	if strings.TrimSpace(rawPackageType) == "" && strings.TrimSpace(rawQuotaMetric) == "" {
+		return DefaultServicePackageAllowBalanceFallback(packageType, quotaMetric)
+	}
+	return false
+}
+
+func validateServicePackageScopeFields(scopeType string, provider string, model string, endpoint string) error {
+	return nil
+}
+
+func validateServicePackageQuotaFields(packageType string, quotaMetric string, periodType string, periodLimit int64) error {
+	switch packageType {
+	case ServicePackageTypeYYCQuota:
+		if quotaMetric != ServicePackageQuotaMetricYYC {
+			return fmt.Errorf("YYC 套餐只能使用 yyc 额度指标")
+		}
+	case ServicePackageTypeRequestQuota:
+		if quotaMetric != ServicePackageQuotaMetricRequestCount {
+			return fmt.Errorf("请求次数套餐只能使用 request_count 额度指标")
+		}
+		if periodType == ServicePackagePeriodNone {
+			return fmt.Errorf("请求次数套餐必须配置周期类型")
+		}
+		if periodLimit <= 0 {
+			return fmt.Errorf("请求次数套餐必须配置周期额度")
+		}
+	}
+	return nil
+}
+
+func normalizeServicePackageScopeAndQuota(item *ServicePackage) {
+	if item == nil {
+		return
+	}
+	rawPackageType := item.PackageType
+	rawQuotaMetric := item.QuotaMetric
+	packageType := normalizeServicePackagePackageType(item.PackageType, item.QuotaMetric)
+	quotaMetric := normalizeServicePackageQuotaMetric(item.QuotaMetric, packageType)
+	scopeType, scopeProvider, scopeModel, scopeEndpoint := normalizeServicePackageScopeFields(
+		item.ScopeType,
+		item.ScopeProvider,
+		item.ScopeModel,
+		item.ScopeEndpoint,
+	)
+	periodType := normalizeServicePackagePeriodType(item.PeriodType, quotaMetric)
+	periodLimit := normalizeServicePackagePeriodLimit(item.PeriodLimit, quotaMetric, periodType, item.DailyQuotaLimit)
+	item.PackageType = packageType
+	item.ScopeType = scopeType
+	item.ScopeProvider = scopeProvider
+	item.ScopeModel = scopeModel
+	item.ScopeEndpoint = scopeEndpoint
+	item.QuotaMetric = quotaMetric
+	item.PeriodType = periodType
+	item.PeriodLimit = periodLimit
+	item.MaxConcurrencyPerUser = normalizeServicePackageConcurrencyLimit(item.MaxConcurrencyPerUser)
+	item.MaxConcurrencyPerPackage = normalizeServicePackageConcurrencyLimit(item.MaxConcurrencyPerPackage)
+	item.AllowBalanceFallback = normalizeServicePackageAllowBalanceFallback(
+		item.AllowBalanceFallback,
+		rawPackageType,
+		rawQuotaMetric,
+		packageType,
+		quotaMetric,
+	)
+}
+
+func validateServicePackageScopeAndQuota(item ServicePackage) error {
+	if err := validateServicePackageScopeFields(item.ScopeType, item.ScopeProvider, item.ScopeModel, item.ScopeEndpoint); err != nil {
+		return err
+	}
+	return validateServicePackageQuotaFields(item.PackageType, item.QuotaMetric, item.PeriodType, item.PeriodLimit)
 }
 
 func normalizeServicePackageVisibleUserIDs(values []string) []string {
@@ -485,15 +652,32 @@ func createServicePackageWithDB(db *gorm.DB, item ServicePackage) (ServicePackag
 		return ServicePackage{}, err
 	}
 	now := helper.GetTimestamp()
+	normalizedItem := item
+	normalizedItem.DailyQuotaLimit = normalizeServicePackageDailyQuotaLimit(item.DailyQuotaLimit)
+	normalizeServicePackageScopeAndQuota(&normalizedItem)
+	if err := validateServicePackageScopeAndQuota(normalizedItem); err != nil {
+		return ServicePackage{}, err
+	}
 	row := ServicePackage{
 		Id:                         strings.TrimSpace(item.Id),
 		Name:                       name,
 		Description:                normalizeServicePackageDescription(item.Description),
 		GroupID:                    groupID,
+		PackageType:                normalizedItem.PackageType,
+		ScopeType:                  normalizedItem.ScopeType,
+		ScopeProvider:              normalizedItem.ScopeProvider,
+		ScopeModel:                 normalizedItem.ScopeModel,
+		ScopeEndpoint:              normalizedItem.ScopeEndpoint,
+		QuotaMetric:                normalizedItem.QuotaMetric,
+		PeriodType:                 normalizedItem.PeriodType,
+		PeriodLimit:                normalizedItem.PeriodLimit,
+		MaxConcurrencyPerUser:      normalizedItem.MaxConcurrencyPerUser,
+		MaxConcurrencyPerPackage:   normalizedItem.MaxConcurrencyPerPackage,
+		AllowBalanceFallback:       normalizedItem.AllowBalanceFallback,
 		VisibilityScope:            visibilityScope,
 		SalePrice:                  normalizeServicePackageSalePrice(item.SalePrice),
 		SaleCurrency:               normalizeServicePackageSaleCurrency(item.SaleCurrency),
-		DailyQuotaLimit:            normalizeServicePackageDailyQuotaLimit(item.DailyQuotaLimit),
+		DailyQuotaLimit:            normalizedItem.DailyQuotaLimit,
 		PackageEmergencyQuotaLimit: normalizeServicePackagePackageEmergencyQuotaLimit(item.PackageEmergencyQuotaLimit),
 		DurationDays:               normalizeServicePackageDurationDays(item.DurationDays),
 		QuotaResetTimezone:         normalizeServicePackageTimezone(item.QuotaResetTimezone),
@@ -570,6 +754,17 @@ func updateServicePackageWithDB(db *gorm.DB, item ServicePackage) (ServicePackag
 	row.Name = nextName
 	row.Description = normalizeServicePackageDescription(item.Description)
 	row.GroupID = groupID
+	row.PackageType = item.PackageType
+	row.ScopeType = item.ScopeType
+	row.ScopeProvider = item.ScopeProvider
+	row.ScopeModel = item.ScopeModel
+	row.ScopeEndpoint = item.ScopeEndpoint
+	row.QuotaMetric = item.QuotaMetric
+	row.PeriodType = item.PeriodType
+	row.PeriodLimit = item.PeriodLimit
+	row.MaxConcurrencyPerUser = item.MaxConcurrencyPerUser
+	row.MaxConcurrencyPerPackage = item.MaxConcurrencyPerPackage
+	row.AllowBalanceFallback = item.AllowBalanceFallback
 	row.VisibilityScope = visibilityScope
 	row.SalePrice = normalizeServicePackageSalePrice(item.SalePrice)
 	row.SaleCurrency = normalizeServicePackageSaleCurrency(item.SaleCurrency)
@@ -577,6 +772,10 @@ func updateServicePackageWithDB(db *gorm.DB, item ServicePackage) (ServicePackag
 	row.PackageEmergencyQuotaLimit = normalizeServicePackagePackageEmergencyQuotaLimit(item.PackageEmergencyQuotaLimit)
 	row.DurationDays = normalizeServicePackageDurationDays(item.DurationDays)
 	row.QuotaResetTimezone = normalizeServicePackageTimezone(item.QuotaResetTimezone)
+	normalizeServicePackageScopeAndQuota(&row)
+	if err := validateServicePackageScopeAndQuota(row); err != nil {
+		return ServicePackage{}, err
+	}
 	row.Enabled = item.Enabled
 	if item.SortOrder > 0 {
 		row.SortOrder = item.SortOrder

--- a/internal/admin/model/service_package_scope_test.go
+++ b/internal/admin/model/service_package_scope_test.go
@@ -1,0 +1,525 @@
+package model
+
+import (
+	"testing"
+	"time"
+
+	"gorm.io/driver/sqlite"
+	"gorm.io/gorm"
+)
+
+func newServicePackageScopeTestDB(t *testing.T) *gorm.DB {
+	t.Helper()
+	db, err := gorm.Open(sqlite.Open("file:"+t.Name()+"?mode=memory&cache=private"), &gorm.Config{})
+	if err != nil {
+		t.Fatalf("open sqlite: %v", err)
+	}
+	if err := db.AutoMigrate(
+		&User{},
+		&GroupCatalog{},
+		&ServicePackage{},
+		&ServicePackageVisibleUser{},
+		&UserPackageSubscription{},
+		&UserPackageUsageCounter{},
+	); err != nil {
+		t.Fatalf("AutoMigrate: %v", err)
+	}
+	if err := db.Create(&GroupCatalog{
+		Id:      "group-1",
+		Name:    "default",
+		Enabled: true,
+	}).Error; err != nil {
+		t.Fatalf("seed group: %v", err)
+	}
+	if err := db.Create(&User{
+		Id:       "user-1",
+		Username: "user1",
+		Password: "password123",
+		Status:   UserStatusEnabled,
+	}).Error; err != nil {
+		t.Fatalf("seed user: %v", err)
+	}
+	return db
+}
+
+func TestCreateServicePackageDefaultsLegacyYYCScopeFields(t *testing.T) {
+	db := newServicePackageScopeTestDB(t)
+
+	row, err := createServicePackageWithDB(db, ServicePackage{
+		Name:            "legacy yyc",
+		GroupID:         "group-1",
+		DailyQuotaLimit: 1000,
+		Enabled:         true,
+	})
+	if err != nil {
+		t.Fatalf("createServicePackageWithDB returned error: %v", err)
+	}
+
+	if row.PackageType != ServicePackageTypeYYCQuota {
+		t.Fatalf("package_type=%q, want %q", row.PackageType, ServicePackageTypeYYCQuota)
+	}
+	if row.ScopeType != ServicePackageScopeAll {
+		t.Fatalf("scope_type=%q, want %q", row.ScopeType, ServicePackageScopeAll)
+	}
+	if row.QuotaMetric != ServicePackageQuotaMetricYYC {
+		t.Fatalf("quota_metric=%q, want %q", row.QuotaMetric, ServicePackageQuotaMetricYYC)
+	}
+	if row.PeriodType != ServicePackagePeriodDaily {
+		t.Fatalf("period_type=%q, want %q", row.PeriodType, ServicePackagePeriodDaily)
+	}
+	if row.PeriodLimit != 1000 {
+		t.Fatalf("period_limit=%d, want 1000", row.PeriodLimit)
+	}
+	if !row.AllowBalanceFallback {
+		t.Fatalf("allow_balance_fallback=false, want true for legacy YYC package")
+	}
+}
+
+func TestCreateServicePackageUsesGroupMonthlyRequestQuota(t *testing.T) {
+	db := newServicePackageScopeTestDB(t)
+
+	row, err := createServicePackageWithDB(db, ServicePackage{
+		Name:                     "glm monthly",
+		GroupID:                  "group-1",
+		PackageType:              ServicePackageTypeRequestQuota,
+		ScopeProvider:            " ZHIPU ",
+		ScopeModel:               "glm-5.2",
+		QuotaMetric:              ServicePackageQuotaMetricRequestCount,
+		PeriodLimit:              25000,
+		MaxConcurrencyPerUser:    3,
+		MaxConcurrencyPerPackage: 100,
+		Enabled:                  true,
+	})
+	if err != nil {
+		t.Fatalf("createServicePackageWithDB returned error: %v", err)
+	}
+
+	if row.ScopeType != ServicePackageScopeAll {
+		t.Fatalf("scope_type=%q, want %q", row.ScopeType, ServicePackageScopeAll)
+	}
+	if row.ScopeProvider != "" || row.ScopeModel != "" || row.ScopeEndpoint != "" {
+		t.Fatalf("scope fields=%q/%q/%q, want empty because package capabilities are defined by group", row.ScopeProvider, row.ScopeModel, row.ScopeEndpoint)
+	}
+	if row.PeriodType != ServicePackagePeriodMonthly {
+		t.Fatalf("period_type=%q, want %q", row.PeriodType, ServicePackagePeriodMonthly)
+	}
+	if row.PeriodLimit != 25000 {
+		t.Fatalf("period_limit=%d, want 25000", row.PeriodLimit)
+	}
+	if row.AllowBalanceFallback {
+		t.Fatalf("allow_balance_fallback=true, want false for request quota unless explicit")
+	}
+}
+
+func TestAssignServicePackageSnapshotsGroupQuotaFields(t *testing.T) {
+	db := newServicePackageScopeTestDB(t)
+	servicePackage, err := createServicePackageWithDB(db, ServicePackage{
+		Name:                     "glm monthly",
+		GroupID:                  "group-1",
+		PackageType:              ServicePackageTypeRequestQuota,
+		ScopeProvider:            "zhipu",
+		ScopeModel:               "glm-5.2",
+		QuotaMetric:              ServicePackageQuotaMetricRequestCount,
+		PeriodLimit:              25000,
+		MaxConcurrencyPerUser:    3,
+		MaxConcurrencyPerPackage: 100,
+		Enabled:                  true,
+	})
+	if err != nil {
+		t.Fatalf("createServicePackageWithDB returned error: %v", err)
+	}
+
+	subscription, err := AssignServicePackageToUserWithDB(db, servicePackage.Id, "user-1", 100)
+	if err != nil {
+		t.Fatalf("AssignServicePackageToUserWithDB returned error: %v", err)
+	}
+
+	if subscription.PackageType != ServicePackageTypeRequestQuota {
+		t.Fatalf("subscription package_type=%q, want %q", subscription.PackageType, ServicePackageTypeRequestQuota)
+	}
+	if subscription.ScopeType != ServicePackageScopeAll {
+		t.Fatalf("subscription scope_type=%q, want %q", subscription.ScopeType, ServicePackageScopeAll)
+	}
+	if subscription.ScopeProvider != "" || subscription.ScopeModel != "" || subscription.ScopeEndpoint != "" {
+		t.Fatalf("subscription scope=%q/%q/%q, want empty because package capabilities are defined by group", subscription.ScopeProvider, subscription.ScopeModel, subscription.ScopeEndpoint)
+	}
+	if subscription.QuotaMetric != ServicePackageQuotaMetricRequestCount {
+		t.Fatalf("subscription quota_metric=%q, want %q", subscription.QuotaMetric, ServicePackageQuotaMetricRequestCount)
+	}
+	if subscription.PeriodType != ServicePackagePeriodMonthly || subscription.PeriodLimit != 25000 {
+		t.Fatalf("subscription period=%q/%d, want monthly/25000", subscription.PeriodType, subscription.PeriodLimit)
+	}
+	if subscription.MaxConcurrencyPerUser != 3 || subscription.MaxConcurrencyPerPackage != 100 {
+		t.Fatalf("subscription concurrency=%d/%d, want 3/100", subscription.MaxConcurrencyPerUser, subscription.MaxConcurrencyPerPackage)
+	}
+}
+
+func TestMigrateServicePackageScopeAndUsageCountersBackfillsLegacyRows(t *testing.T) {
+	db, err := gorm.Open(sqlite.Open("file:"+t.Name()+"?mode=memory&cache=private"), &gorm.Config{})
+	if err != nil {
+		t.Fatalf("open sqlite: %v", err)
+	}
+	if err := db.AutoMigrate(&ServicePackage{}, &UserPackageSubscription{}); err != nil {
+		t.Fatalf("AutoMigrate legacy tables: %v", err)
+	}
+	if err := db.Exec(`
+		UPDATE service_packages
+		SET package_type = '', scope_type = '', quota_metric = '', period_type = '', period_limit = 0, allow_balance_fallback = FALSE
+	`).Error; err != nil {
+		t.Fatalf("prepare service package defaults: %v", err)
+	}
+	if err := db.Create(&ServicePackage{
+		Id:              "package-1",
+		Name:            "legacy",
+		GroupID:         "group-1",
+		DailyQuotaLimit: 1234,
+	}).Error; err != nil {
+		t.Fatalf("seed service package: %v", err)
+	}
+	if err := db.Exec(`
+		UPDATE service_packages
+		SET package_type = '', scope_type = '', quota_metric = '', period_type = '', period_limit = 0, allow_balance_fallback = FALSE
+		WHERE id = 'package-1'
+	`).Error; err != nil {
+		t.Fatalf("blank service package scope fields: %v", err)
+	}
+	if err := db.Create(&UserPackageSubscription{
+		Id:              "subscription-1",
+		UserID:          "user-1",
+		PackageID:       "package-1",
+		PackageName:     "legacy",
+		GroupID:         "group-1",
+		DailyQuotaLimit: 1234,
+		Status:          UserPackageSubscriptionStatusActive,
+	}).Error; err != nil {
+		t.Fatalf("seed subscription: %v", err)
+	}
+	if err := db.Exec(`
+		UPDATE user_package_subscriptions
+		SET package_type = '', scope_type = '', quota_metric = '', period_type = '', period_limit = 0, allow_balance_fallback = FALSE
+		WHERE id = 'subscription-1'
+	`).Error; err != nil {
+		t.Fatalf("blank subscription scope fields: %v", err)
+	}
+
+	if err := migrateServicePackageScopeAndUsageCountersWithDB(db); err != nil {
+		t.Fatalf("migrateServicePackageScopeAndUsageCountersWithDB returned error: %v", err)
+	}
+
+	servicePackage := ServicePackage{}
+	if err := db.First(&servicePackage, "id = ?", "package-1").Error; err != nil {
+		t.Fatalf("load service package: %v", err)
+	}
+	if servicePackage.PackageType != ServicePackageTypeYYCQuota ||
+		servicePackage.ScopeType != ServicePackageScopeAll ||
+		servicePackage.QuotaMetric != ServicePackageQuotaMetricYYC ||
+		servicePackage.PeriodType != ServicePackagePeriodDaily ||
+		servicePackage.PeriodLimit != 1234 ||
+		!servicePackage.AllowBalanceFallback {
+		t.Fatalf("service package backfill mismatch: %+v", servicePackage)
+	}
+
+	subscription := UserPackageSubscription{}
+	if err := db.First(&subscription, "id = ?", "subscription-1").Error; err != nil {
+		t.Fatalf("load subscription: %v", err)
+	}
+	if subscription.PackageType != ServicePackageTypeYYCQuota ||
+		subscription.ScopeType != ServicePackageScopeAll ||
+		subscription.QuotaMetric != ServicePackageQuotaMetricYYC ||
+		subscription.PeriodType != ServicePackagePeriodDaily ||
+		subscription.PeriodLimit != 1234 ||
+		!subscription.AllowBalanceFallback {
+		t.Fatalf("subscription backfill mismatch: %+v", subscription)
+	}
+	if !db.Migrator().HasTable(&UserPackageUsageCounter{}) {
+		t.Fatalf("user package usage counter table was not created")
+	}
+}
+
+func TestReserveRequestPackageMatchesGroupAndSettlesMonthlyCounter(t *testing.T) {
+	db := newServicePackageScopeTestDB(t)
+	servicePackage, err := createServicePackageWithDB(db, ServicePackage{
+		Name:                  "glm monthly",
+		GroupID:               "group-1",
+		PackageType:           ServicePackageTypeRequestQuota,
+		QuotaMetric:           ServicePackageQuotaMetricRequestCount,
+		PeriodLimit:           2,
+		AllowBalanceFallback:  false,
+		MaxConcurrencyPerUser: 1,
+		Enabled:               true,
+	})
+	if err != nil {
+		t.Fatalf("createServicePackageWithDB returned error: %v", err)
+	}
+	if _, err := AssignServicePackageToUserWithDB(db, servicePackage.Id, "user-1", 0); err != nil {
+		t.Fatalf("AssignServicePackageToUserWithDB returned error: %v", err)
+	}
+	now := time.Now()
+	wantPeriodKey := businessMonthByTimezone(now, DefaultGroupQuotaResetTimezone)
+
+	result, err := ReserveRequestPackageWithDB(db, PackageScopeRequest{
+		UserID:  "user-1",
+		GroupID: "group-1",
+		Now:     now,
+	})
+	if err != nil {
+		t.Fatalf("ReserveRequestPackageWithDB returned error: %v", err)
+	}
+	if !result.Matched || !result.Allowed || !result.Reservation.Active() {
+		t.Fatalf("reserve result mismatch: %+v", result)
+	}
+	if result.Reservation.PeriodKey != wantPeriodKey {
+		t.Fatalf("period_key=%q, want %s", result.Reservation.PeriodKey, wantPeriodKey)
+	}
+
+	blocked, err := ReserveRequestPackageWithDB(db, PackageScopeRequest{
+		UserID:  "user-1",
+		GroupID: "group-1",
+		Now:     now,
+	})
+	if err != nil {
+		t.Fatalf("second ReserveRequestPackageWithDB returned error: %v", err)
+	}
+	if !blocked.Matched || blocked.Allowed || blocked.Reason != "request_concurrency_per_user_exceeded" {
+		t.Fatalf("second reserve result mismatch: %+v", blocked)
+	}
+
+	if err := ReleaseRequestPackageReservationWithDB(db, result.Reservation); err != nil {
+		t.Fatalf("ReleaseRequestPackageReservationWithDB returned error: %v", err)
+	}
+	result, err = ReserveRequestPackageWithDB(db, PackageScopeRequest{
+		UserID:  "user-1",
+		GroupID: "group-1",
+		Now:     now,
+	})
+	if err != nil {
+		t.Fatalf("third ReserveRequestPackageWithDB returned error: %v", err)
+	}
+	if !result.Allowed {
+		t.Fatalf("third reserve not allowed: %+v", result)
+	}
+	settled, err := SettleRequestPackageReservationWithDB(db, result.Reservation, 1)
+	if err != nil {
+		t.Fatalf("SettleRequestPackageReservationWithDB returned error: %v", err)
+	}
+	if settled != 1 {
+		t.Fatalf("settled=%d, want 1", settled)
+	}
+
+	result, err = ReserveRequestPackageWithDB(db, PackageScopeRequest{
+		UserID:  "user-1",
+		GroupID: "group-1",
+		Now:     now,
+	})
+	if err != nil {
+		t.Fatalf("fourth ReserveRequestPackageWithDB returned error: %v", err)
+	}
+	if !result.Allowed {
+		t.Fatalf("fourth reserve not allowed: %+v", result)
+	}
+	if _, err := SettleRequestPackageReservationWithDB(db, result.Reservation, 1); err != nil {
+		t.Fatalf("second settle returned error: %v", err)
+	}
+	exhausted, err := ReserveRequestPackageWithDB(db, PackageScopeRequest{
+		UserID:  "user-1",
+		GroupID: "group-1",
+		Now:     now,
+	})
+	if err != nil {
+		t.Fatalf("exhausted ReserveRequestPackageWithDB returned error: %v", err)
+	}
+	if !exhausted.Matched || exhausted.Allowed || exhausted.Reason != "request_quota_exhausted" {
+		t.Fatalf("exhausted result mismatch: %+v", exhausted)
+	}
+}
+
+func TestReserveRequestPackageIgnoresDifferentGroup(t *testing.T) {
+	db := newServicePackageScopeTestDB(t)
+	servicePackage, err := createServicePackageWithDB(db, ServicePackage{
+		Name:        "glm monthly",
+		GroupID:     "group-1",
+		PackageType: ServicePackageTypeRequestQuota,
+		QuotaMetric: ServicePackageQuotaMetricRequestCount,
+		PeriodLimit: 2,
+		Enabled:     true,
+	})
+	if err != nil {
+		t.Fatalf("createServicePackageWithDB returned error: %v", err)
+	}
+	if _, err := AssignServicePackageToUserWithDB(db, servicePackage.Id, "user-1", 0); err != nil {
+		t.Fatalf("AssignServicePackageToUserWithDB returned error: %v", err)
+	}
+
+	result, err := ReserveRequestPackageWithDB(db, PackageScopeRequest{
+		UserID:  "user-1",
+		GroupID: "group-2",
+	})
+	if err != nil {
+		t.Fatalf("ReserveRequestPackageWithDB returned error: %v", err)
+	}
+	if result.Matched || result.Allowed {
+		t.Fatalf("different group package should not match: %+v", result)
+	}
+}
+
+func TestAssignServicePackageAllowsDifferentGroupsToCoexist(t *testing.T) {
+	db := newServicePackageScopeTestDB(t)
+	if err := db.Create(&GroupCatalog{
+		Id:      "group-2",
+		Name:    "qwen",
+		Enabled: true,
+	}).Error; err != nil {
+		t.Fatalf("seed second group: %v", err)
+	}
+	firstPackage, err := createServicePackageWithDB(db, ServicePackage{
+		Name:        "glm monthly",
+		GroupID:     "group-1",
+		PackageType: ServicePackageTypeRequestQuota,
+		QuotaMetric: ServicePackageQuotaMetricRequestCount,
+		PeriodLimit: 25000,
+		Enabled:     true,
+	})
+	if err != nil {
+		t.Fatalf("create first package: %v", err)
+	}
+	secondPackage, err := createServicePackageWithDB(db, ServicePackage{
+		Name:        "qwen monthly",
+		GroupID:     "group-2",
+		PackageType: ServicePackageTypeRequestQuota,
+		QuotaMetric: ServicePackageQuotaMetricRequestCount,
+		PeriodLimit: 25000,
+		Enabled:     true,
+	})
+	if err != nil {
+		t.Fatalf("create second package: %v", err)
+	}
+	if _, err := AssignServicePackageToUserWithDB(db, firstPackage.Id, "user-1", 0); err != nil {
+		t.Fatalf("assign first package: %v", err)
+	}
+	if _, err := AssignServicePackageToUserWithDB(db, secondPackage.Id, "user-1", 0); err != nil {
+		t.Fatalf("assign second package: %v", err)
+	}
+
+	rows, err := listActiveUserPackageSubscriptionsWithDB(db, "user-1")
+	if err != nil {
+		t.Fatalf("list active subscriptions: %v", err)
+	}
+	if len(rows) != 2 {
+		t.Fatalf("active subscription count=%d, want 2: %+v", len(rows), rows)
+	}
+	groups := map[string]bool{}
+	for _, row := range rows {
+		groups[row.GroupID] = true
+	}
+	if !groups["group-1"] || !groups["group-2"] {
+		t.Fatalf("active groups=%v, want group-1 and group-2", groups)
+	}
+}
+
+func TestAssignServicePackageReplacesSameGroupRequestQuota(t *testing.T) {
+	db := newServicePackageScopeTestDB(t)
+	firstPackage, err := createServicePackageWithDB(db, ServicePackage{
+		Name:        "glm monthly small",
+		GroupID:     "group-1",
+		PackageType: ServicePackageTypeRequestQuota,
+		QuotaMetric: ServicePackageQuotaMetricRequestCount,
+		PeriodLimit: 100,
+		Enabled:     true,
+	})
+	if err != nil {
+		t.Fatalf("create first package: %v", err)
+	}
+	secondPackage, err := createServicePackageWithDB(db, ServicePackage{
+		Name:        "glm monthly large",
+		GroupID:     "group-1",
+		PackageType: ServicePackageTypeRequestQuota,
+		QuotaMetric: ServicePackageQuotaMetricRequestCount,
+		PeriodLimit: 25000,
+		Enabled:     true,
+	})
+	if err != nil {
+		t.Fatalf("create second package: %v", err)
+	}
+	if _, err := AssignServicePackageToUserWithDB(db, firstPackage.Id, "user-1", 0); err != nil {
+		t.Fatalf("assign first package: %v", err)
+	}
+	if _, err := AssignServicePackageToUserWithDB(db, secondPackage.Id, "user-1", 0); err != nil {
+		t.Fatalf("assign second package: %v", err)
+	}
+
+	rows, err := listActiveUserPackageSubscriptionsWithDB(db, "user-1")
+	if err != nil {
+		t.Fatalf("list active subscriptions: %v", err)
+	}
+	if len(rows) != 1 {
+		t.Fatalf("active subscription count=%d, want 1: %+v", len(rows), rows)
+	}
+	if rows[0].PackageID != secondPackage.Id || rows[0].PeriodLimit != 25000 {
+		t.Fatalf("active subscription=%+v, want second package with limit 25000", rows[0])
+	}
+	replaced := int64(0)
+	if err := db.Model(&UserPackageSubscription{}).
+		Where("package_id = ? AND status = ?", firstPackage.Id, UserPackageSubscriptionStatusReplaced).
+		Count(&replaced).Error; err != nil {
+		t.Fatalf("count replaced first package: %v", err)
+	}
+	if replaced != 1 {
+		t.Fatalf("replaced first package count=%d, want 1", replaced)
+	}
+}
+
+func TestRequestPackageUsageSnapshotReportsCurrentPeriodUsage(t *testing.T) {
+	db := newServicePackageScopeTestDB(t)
+	servicePackage, err := createServicePackageWithDB(db, ServicePackage{
+		Name:        "glm monthly",
+		GroupID:     "group-1",
+		PackageType: ServicePackageTypeRequestQuota,
+		QuotaMetric: ServicePackageQuotaMetricRequestCount,
+		PeriodLimit: 2,
+		Enabled:     true,
+	})
+	if err != nil {
+		t.Fatalf("create package: %v", err)
+	}
+	subscription, err := AssignServicePackageToUserWithDB(db, servicePackage.Id, "user-1", 0)
+	if err != nil {
+		t.Fatalf("assign package: %v", err)
+	}
+	now := time.Now()
+	initial, err := GetRequestPackageUsageSnapshotWithDB(db, subscription, now)
+	if err != nil {
+		t.Fatalf("initial snapshot: %v", err)
+	}
+	if initial.LimitAmount != 2 || initial.RemainingAmount != 2 || initial.ConsumedAmount != 0 || initial.ReservedAmount != 0 {
+		t.Fatalf("initial snapshot=%+v, want limit/remaining 2 and no usage", initial)
+	}
+
+	reserved, err := ReserveRequestPackageWithDB(db, PackageScopeRequest{
+		UserID:  "user-1",
+		GroupID: "group-1",
+		Now:     now,
+	})
+	if err != nil {
+		t.Fatalf("reserve package: %v", err)
+	}
+	if !reserved.Allowed {
+		t.Fatalf("reserve not allowed: %+v", reserved)
+	}
+	afterReserve, err := GetRequestPackageUsageSnapshotWithDB(db, subscription, now)
+	if err != nil {
+		t.Fatalf("snapshot after reserve: %v", err)
+	}
+	if afterReserve.ReservedAmount != 1 || afterReserve.ConsumedAmount != 0 || afterReserve.RemainingAmount != 1 {
+		t.Fatalf("after reserve snapshot=%+v, want reserved=1 consumed=0 remaining=1", afterReserve)
+	}
+	if _, err := SettleRequestPackageReservationWithDB(db, reserved.Reservation, 1); err != nil {
+		t.Fatalf("settle package: %v", err)
+	}
+	afterSettle, err := GetRequestPackageUsageSnapshotWithDB(db, subscription, now)
+	if err != nil {
+		t.Fatalf("snapshot after settle: %v", err)
+	}
+	if afterSettle.ReservedAmount != 0 || afterSettle.ConsumedAmount != 1 || afterSettle.RemainingAmount != 1 {
+		t.Fatalf("after settle snapshot=%+v, want reserved=0 consumed=1 remaining=1", afterSettle)
+	}
+}

--- a/internal/admin/model/topup_order.go
+++ b/internal/admin/model/topup_order.go
@@ -456,7 +456,7 @@ func PreviewPackagePurchaseWithDB(db *gorm.DB, userID string, packageID string, 
 		return PackagePurchasePreview{}, err
 	}
 	var active *UserPackageSubscription
-	activeSubscription, activeErr := getActiveUserPackageSubscriptionWithDB(db, normalizedUserID)
+	activeSubscription, activeErr := getActiveUserPackageSubscriptionForPackageGroupWithDB(db, normalizedUserID, targetPackage, effectiveNow)
 	if activeErr == nil {
 		active = &activeSubscription
 	} else if !errors.Is(activeErr, gorm.ErrRecordNotFound) {
@@ -484,7 +484,7 @@ func PreviewPackagePurchaseWithDB(db *gorm.DB, userID string, packageID string, 
 		if strings.TrimSpace(active.PackageID) != normalizedPackageID {
 			return PackagePurchasePreview{}, fmt.Errorf("当前生效套餐与续费套餐不一致")
 		}
-		tailEnd, hasUnlimitedTail, err := latestUserPackageSubscriptionTailWithDB(db, normalizedUserID)
+		tailEnd, hasUnlimitedTail, err := latestUserPackageSubscriptionTailForPackageGroupWithDB(db, normalizedUserID, targetPackage)
 		if err != nil {
 			return PackagePurchasePreview{}, err
 		}

--- a/internal/admin/model/user_balance_lot_amount_migration.go
+++ b/internal/admin/model/user_balance_lot_amount_migration.go
@@ -50,3 +50,29 @@ func ensureUserBalanceLotAmountColumnsWithDB(tx *gorm.DB) error {
 	}
 	return nil
 }
+
+func ensureUserBalanceLotTransactionAmountColumnsWithDB(tx *gorm.DB) error {
+	if tx == nil {
+		return fmt.Errorf("database handle is nil")
+	}
+	if !tx.Migrator().HasTable(UserBalanceLotTransactionsTableName) {
+		return tx.AutoMigrate(&UserBalanceLotTransaction{})
+	}
+	amountColumns := []string{"DeltaAmount", "LotRemainingBefore", "LotRemainingAfter"}
+	for _, column := range amountColumns {
+		if tx.Migrator().HasColumn(&UserBalanceLotTransaction{}, column) {
+			continue
+		}
+		if err := tx.Migrator().AddColumn(&UserBalanceLotTransaction{}, column); err != nil {
+			return err
+		}
+	}
+	if tx.Migrator().HasColumn(UserBalanceLotTransactionsTableName, "delta_yyc") {
+		if err := tx.Exec(
+			"UPDATE user_balance_lot_transactions SET delta_amount = delta_yyc WHERE COALESCE(delta_amount, 0) = 0 AND COALESCE(delta_yyc, 0) <> 0",
+		).Error; err != nil {
+			return err
+		}
+	}
+	return nil
+}

--- a/internal/admin/model/user_balance_lot_test.go
+++ b/internal/admin/model/user_balance_lot_test.go
@@ -78,6 +78,75 @@ func TestEnsureUserBalanceLotAmountColumnsBackfillsLegacyYYCColumns(t *testing.T
 	}
 }
 
+func TestEnsureUserBalanceLotTransactionAmountColumnsBackfillsLegacyYYCColumn(t *testing.T) {
+	db, err := gorm.Open(sqlite.Open("file:"+t.Name()+"?mode=memory&cache=private"), &gorm.Config{})
+	if err != nil {
+		t.Fatalf("open db: %v", err)
+	}
+	if err := db.Exec(`
+		CREATE TABLE user_balance_lot_transactions (
+			id char(36) PRIMARY KEY,
+			user_id char(36) NOT NULL,
+			lot_id char(36) NOT NULL,
+			source_type varchar(32) NOT NULL,
+			source_id char(36) NOT NULL,
+			tx_type varchar(16) NOT NULL,
+			delta_yyc bigint NOT NULL DEFAULT 0,
+			lot_remaining_before bigint NOT NULL DEFAULT 0,
+			lot_remaining_after bigint NOT NULL DEFAULT 0,
+			occurred_at bigint NOT NULL DEFAULT 0,
+			created_at bigint,
+			updated_at bigint
+		)
+	`).Error; err != nil {
+		t.Fatalf("create legacy transaction table: %v", err)
+	}
+	if err := db.Exec(`
+		INSERT INTO user_balance_lot_transactions (
+			id, user_id, lot_id, source_type, source_id, tx_type, delta_yyc,
+			lot_remaining_before, lot_remaining_after, occurred_at
+		) VALUES (
+			'tx-1', 'user-1', 'lot-1', 'redemption', 'source-1', 'credit', 1000,
+			0, 1000, 1776073942
+		)
+	`).Error; err != nil {
+		t.Fatalf("insert legacy transaction row: %v", err)
+	}
+
+	if err := ensureUserBalanceLotTransactionAmountColumnsWithDB(db); err != nil {
+		t.Fatalf("ensure transaction columns: %v", err)
+	}
+	if !db.Migrator().HasColumn(UserBalanceLotTransactionsTableName, "delta_amount") {
+		t.Fatalf("expected delta_amount column to exist")
+	}
+
+	row := UserBalanceLotTransaction{}
+	if err := db.First(&row, "id = ?", "tx-1").Error; err != nil {
+		t.Fatalf("load migrated transaction row: %v", err)
+	}
+	if row.DeltaAmount != 1000 {
+		t.Fatalf("DeltaAmount=%d, want 1000", row.DeltaAmount)
+	}
+
+	created, err := CreateUserBalanceLotTransactionWithDB(db, UserBalanceLotTransactionInput{
+		UserID:             "user-1",
+		LotID:              "lot-1",
+		SourceType:         UserBalanceLotSourceRedeem,
+		SourceID:           "source-2",
+		TxType:             UserBalanceLotTxTypeCredit,
+		DeltaAmount:        2000,
+		LotRemainingBefore: 1000,
+		LotRemainingAfter:  3000,
+		OccurredAt:         1776073943,
+	})
+	if err != nil {
+		t.Fatalf("create transaction with migrated schema: %v", err)
+	}
+	if created.DeltaAmount != 2000 {
+		t.Fatalf("created DeltaAmount=%d, want 2000", created.DeltaAmount)
+	}
+}
+
 func TestListUserBalanceLotsPageWithDBAllowsAllHistoricalStatuses(t *testing.T) {
 	db, err := gorm.Open(sqlite.Open("file:"+t.Name()+"?mode=memory&cache=private"), &gorm.Config{})
 	if err != nil {

--- a/internal/admin/model/user_package_subscription.go
+++ b/internal/admin/model/user_package_subscription.go
@@ -26,6 +26,17 @@ type UserPackageSubscription struct {
 	PackageID                  string `json:"package_id" gorm:"type:char(36);not null;index"`
 	PackageName                string `json:"package_name" gorm:"type:varchar(64);not null;default:''"`
 	GroupID                    string `json:"group_id" gorm:"type:char(36);not null;index"`
+	PackageType                string `json:"package_type" gorm:"type:varchar(32);not null;default:'yyc_quota';index"`
+	ScopeType                  string `json:"scope_type" gorm:"type:varchar(32);not null;default:'all';index"`
+	ScopeProvider              string `json:"scope_provider" gorm:"type:varchar(64);not null;default:'';index"`
+	ScopeModel                 string `json:"scope_model" gorm:"type:varchar(191);not null;default:'';index"`
+	ScopeEndpoint              string `json:"scope_endpoint" gorm:"type:varchar(191);not null;default:''"`
+	QuotaMetric                string `json:"quota_metric" gorm:"type:varchar(32);not null;default:'yyc';index"`
+	PeriodType                 string `json:"period_type" gorm:"type:varchar(32);not null;default:'daily';index"`
+	PeriodLimit                int64  `json:"period_limit" gorm:"type:bigint;not null;default:0"`
+	MaxConcurrencyPerUser      int    `json:"max_concurrency_per_user" gorm:"type:int;not null;default:0"`
+	MaxConcurrencyPerPackage   int    `json:"max_concurrency_per_package" gorm:"type:int;not null;default:0"`
+	AllowBalanceFallback       bool   `json:"allow_balance_fallback" gorm:"not null;default:false"`
 	DailyQuotaLimit            int64  `json:"daily_quota_limit" gorm:"type:bigint;not null;default:0"`
 	PackageEmergencyQuotaLimit int64  `json:"package_emergency_quota_limit" gorm:"column:package_emergency_quota_limit;type:bigint;not null;default:0"`
 	QuotaResetTimezone         string `json:"quota_reset_timezone" gorm:"type:varchar(64);not null;default:'Asia/Shanghai'"`
@@ -79,22 +90,7 @@ func syncUserPackageSubscriptionsWithDB(db *gorm.DB, userID string, now int64) e
 		if err := markExpiredUserPackageSubscriptionsWithDB(tx, normalizedUserID, effectiveNow); err != nil {
 			return err
 		}
-		activeCount := int64(0)
-		if err := tx.Model(&UserPackageSubscription{}).
-			Where("user_id = ? AND status = ? AND started_at <= ? AND (expires_at = 0 OR expires_at > ?)",
-				normalizedUserID,
-				UserPackageSubscriptionStatusActive,
-				effectiveNow,
-				effectiveNow,
-			).
-			Count(&activeCount).Error; err != nil {
-			return err
-		}
-		if activeCount > 0 {
-			return nil
-		}
-
-		pending := UserPackageSubscription{}
+		pendingRows := make([]UserPackageSubscription, 0)
 		if err := tx.
 			Where("user_id = ? AND status = ? AND started_at <= ?",
 				normalizedUserID,
@@ -102,27 +98,55 @@ func syncUserPackageSubscriptionsWithDB(db *gorm.DB, userID string, now int64) e
 				effectiveNow,
 			).
 			Order("started_at asc, updated_at desc, id desc").
-			First(&pending).Error; err != nil {
-			if errors.Is(err, gorm.ErrRecordNotFound) {
-				return nil
+			Find(&pendingRows).Error; err != nil {
+			return err
+		}
+		for _, pending := range pendingRows {
+			normalizeServicePackageSubscriptionScopeAndQuota(&pending)
+			activeCount := int64(0)
+			query := tx.Model(&UserPackageSubscription{}).
+				Where("user_id = ? AND status = ? AND started_at <= ? AND (expires_at = 0 OR expires_at > ?)",
+					normalizedUserID,
+					UserPackageSubscriptionStatusActive,
+					effectiveNow,
+					effectiveNow,
+				)
+			query = applyUserPackageSubscriptionScopeIdentityFilter(query, pending)
+			if err := query.Count(&activeCount).Error; err != nil {
+				return err
 			}
-			return err
+			if activeCount > 0 {
+				continue
+			}
+			if err := tx.Model(&UserPackageSubscription{}).
+				Where("id = ?", strings.TrimSpace(pending.Id)).
+				Updates(map[string]any{
+					"status":     UserPackageSubscriptionStatusActive,
+					"updated_at": effectiveNow,
+				}).Error; err != nil {
+				return err
+			}
+			if err := syncUserFieldsForActivePackageSubscriptionWithDB(tx, normalizedUserID, pending); err != nil {
+				return err
+			}
 		}
-
-		if err := tx.Model(&UserPackageSubscription{}).
-			Where("id = ?", strings.TrimSpace(pending.Id)).
-			Updates(map[string]any{
-				"status":     UserPackageSubscriptionStatusActive,
-				"updated_at": effectiveNow,
-			}).Error; err != nil {
-			return err
-		}
-
-		return tx.Model(&User{}).Where("id = ?", normalizedUserID).Updates(map[string]any{
-			"group":                strings.TrimSpace(pending.GroupID),
-			"quota_reset_timezone": normalizeUserQuotaResetTimezone(pending.QuotaResetTimezone),
-		}).Error
+		return nil
 	})
+}
+
+func applyUserPackageSubscriptionScopeIdentityFilter(query *gorm.DB, subscription UserPackageSubscription) *gorm.DB {
+	normalizeServicePackageSubscriptionScopeAndQuota(&subscription)
+	return query.
+		Where("package_type = ?", strings.TrimSpace(subscription.PackageType)).
+		Where("quota_metric = ?", strings.TrimSpace(subscription.QuotaMetric)).
+		Where("COALESCE(group_id, '') = ?", strings.TrimSpace(subscription.GroupID))
+}
+
+func syncUserFieldsForActivePackageSubscriptionWithDB(tx *gorm.DB, userID string, subscription UserPackageSubscription) error {
+	return tx.Model(&User{}).Where("id = ?", strings.TrimSpace(userID)).Updates(map[string]any{
+		"group":                strings.TrimSpace(subscription.GroupID),
+		"quota_reset_timezone": normalizeUserQuotaResetTimezone(subscription.QuotaResetTimezone),
+	}).Error
 }
 
 func getActiveUserPackageSubscriptionWithDB(db *gorm.DB, userID string) (UserPackageSubscription, error) {
@@ -165,6 +189,86 @@ func getActiveUserPackageSubscriptionForGroupWithDB(db *gorm.DB, userID string, 
 	}
 	row := UserPackageSubscription{}
 	err := db.Where("user_id = ? AND group_id = ? AND status = ? AND started_at <= ? AND (expires_at = 0 OR expires_at > ?)", normalizedUserID, normalizedGroupID, UserPackageSubscriptionStatusActive, now, now).
+		Order("updated_at desc").
+		First(&row).Error
+	if err != nil {
+		return UserPackageSubscription{}, err
+	}
+	return row, nil
+}
+
+func getActiveUserPackageSubscriptionForPackageGroupWithDB(db *gorm.DB, userID string, servicePackage ServicePackage, now int64) (UserPackageSubscription, error) {
+	if db == nil {
+		return UserPackageSubscription{}, fmt.Errorf("database handle is nil")
+	}
+	normalizedUserID := strings.TrimSpace(userID)
+	if normalizedUserID == "" {
+		return UserPackageSubscription{}, fmt.Errorf("用户 ID 不能为空")
+	}
+	normalizeServicePackageScopeAndQuota(&servicePackage)
+	effectiveNow := now
+	if effectiveNow <= 0 {
+		effectiveNow = helper.GetTimestamp()
+	}
+	if err := syncUserPackageSubscriptionsWithDB(db, normalizedUserID, effectiveNow); err != nil {
+		return UserPackageSubscription{}, err
+	}
+	probe := UserPackageSubscription{
+		PackageType: servicePackage.PackageType,
+		GroupID:     servicePackage.GroupID,
+		QuotaMetric: servicePackage.QuotaMetric,
+	}
+	query := db.
+		Where("user_id = ? AND status = ? AND started_at <= ? AND (expires_at = 0 OR expires_at > ?)",
+			normalizedUserID,
+			UserPackageSubscriptionStatusActive,
+			effectiveNow,
+			effectiveNow,
+		)
+	query = applyUserPackageSubscriptionScopeIdentityFilter(query, probe)
+	row := UserPackageSubscription{}
+	if err := query.Order("updated_at desc, started_at desc, id desc").First(&row).Error; err != nil {
+		return UserPackageSubscription{}, err
+	}
+	return row, nil
+}
+
+func getActiveYYCUserPackageSubscriptionForGroupWithDB(db *gorm.DB, userID string, groupID string) (UserPackageSubscription, error) {
+	if db == nil {
+		return UserPackageSubscription{}, fmt.Errorf("database handle is nil")
+	}
+	normalizedUserID := strings.TrimSpace(userID)
+	if normalizedUserID == "" {
+		return UserPackageSubscription{}, fmt.Errorf("用户 ID 不能为空")
+	}
+	normalizedGroupID := strings.TrimSpace(groupID)
+	now := helper.GetTimestamp()
+	if err := syncUserPackageSubscriptionsWithDB(db, normalizedUserID, now); err != nil {
+		return UserPackageSubscription{}, err
+	}
+	row := UserPackageSubscription{}
+	query := db.Where(
+		"user_id = ? AND group_id = ? AND status = ? AND package_type = ? AND quota_metric = ? AND started_at <= ? AND (expires_at = 0 OR expires_at > ?)",
+		normalizedUserID,
+		normalizedGroupID,
+		UserPackageSubscriptionStatusActive,
+		ServicePackageTypeYYCQuota,
+		ServicePackageQuotaMetricYYC,
+		now,
+		now,
+	)
+	if normalizedGroupID == "" {
+		query = db.Where(
+			"user_id = ? AND status = ? AND package_type = ? AND quota_metric = ? AND started_at <= ? AND (expires_at = 0 OR expires_at > ?)",
+			normalizedUserID,
+			UserPackageSubscriptionStatusActive,
+			ServicePackageTypeYYCQuota,
+			ServicePackageQuotaMetricYYC,
+			now,
+			now,
+		)
+	}
+	err := query.
 		Order("updated_at desc").
 		First(&row).Error
 	if err != nil {
@@ -216,11 +320,23 @@ func AssignServicePackageToUserWithDB(db *gorm.DB, packageID string, userID stri
 	if effectiveDurationDays > 0 {
 		expiresAt = effectiveStartAt + int64(effectiveDurationDays)*86400
 	}
+	normalizeServicePackageScopeAndQuota(&servicePackage)
 	subscription := UserPackageSubscription{
 		UserID:                     normalizedUserID,
 		PackageID:                  strings.TrimSpace(servicePackage.Id),
 		PackageName:                strings.TrimSpace(servicePackage.Name),
 		GroupID:                    strings.TrimSpace(servicePackage.GroupID),
+		PackageType:                servicePackage.PackageType,
+		ScopeType:                  servicePackage.ScopeType,
+		ScopeProvider:              servicePackage.ScopeProvider,
+		ScopeModel:                 servicePackage.ScopeModel,
+		ScopeEndpoint:              servicePackage.ScopeEndpoint,
+		QuotaMetric:                servicePackage.QuotaMetric,
+		PeriodType:                 servicePackage.PeriodType,
+		PeriodLimit:                servicePackage.PeriodLimit,
+		MaxConcurrencyPerUser:      servicePackage.MaxConcurrencyPerUser,
+		MaxConcurrencyPerPackage:   servicePackage.MaxConcurrencyPerPackage,
+		AllowBalanceFallback:       servicePackage.AllowBalanceFallback,
 		DailyQuotaLimit:            normalizeServicePackageDailyQuotaLimit(servicePackage.DailyQuotaLimit),
 		PackageEmergencyQuotaLimit: normalizeServicePackagePackageEmergencyQuotaLimit(servicePackage.PackageEmergencyQuotaLimit),
 		QuotaResetTimezone:         normalizeServicePackageTimezone(servicePackage.QuotaResetTimezone),
@@ -235,13 +351,15 @@ func AssignServicePackageToUserWithDB(db *gorm.DB, packageID string, userID stri
 		if err := markExpiredUserPackageSubscriptionsWithDB(tx, normalizedUserID, now); err != nil {
 			return err
 		}
-		if err := tx.Model(&UserPackageSubscription{}).
+		replaceQuery := tx.Model(&UserPackageSubscription{}).
 			Where("user_id = ? AND status IN ? AND started_at <= ? AND (expires_at = 0 OR expires_at > ?)",
 				normalizedUserID,
 				[]int{UserPackageSubscriptionStatusActive, UserPackageSubscriptionStatusPending},
 				effectiveStartAt,
 				effectiveStartAt,
-			).
+			)
+		replaceQuery = applyUserPackageSubscriptionScopeIdentityFilter(replaceQuery, subscription)
+		if err := replaceQuery.
 			Updates(map[string]any{
 				"status":     UserPackageSubscriptionStatusReplaced,
 				"updated_at": now,
@@ -254,10 +372,7 @@ func AssignServicePackageToUserWithDB(db *gorm.DB, packageID string, userID stri
 		if subscription.Status != UserPackageSubscriptionStatusActive {
 			return nil
 		}
-		return tx.Model(&User{}).Where("id = ?", normalizedUserID).Updates(map[string]any{
-			"group":                strings.TrimSpace(servicePackage.GroupID),
-			"quota_reset_timezone": normalizeUserQuotaResetTimezone(subscription.QuotaResetTimezone),
-		}).Error
+		return syncUserFieldsForActivePackageSubscriptionWithDB(tx, normalizedUserID, subscription)
 	})
 	if err != nil {
 		return UserPackageSubscription{}, err
@@ -292,6 +407,39 @@ func latestUserPackageSubscriptionTailWithDB(db *gorm.DB, userID string) (int64,
 	return tailEnd, false, nil
 }
 
+func latestUserPackageSubscriptionTailForPackageGroupWithDB(db *gorm.DB, userID string, servicePackage ServicePackage) (int64, bool, error) {
+	if db == nil {
+		return 0, false, fmt.Errorf("database handle is nil")
+	}
+	normalizedUserID := strings.TrimSpace(userID)
+	if normalizedUserID == "" {
+		return 0, false, fmt.Errorf("用户 ID 不能为空")
+	}
+	normalizeServicePackageScopeAndQuota(&servicePackage)
+	probe := UserPackageSubscription{
+		PackageType: servicePackage.PackageType,
+		GroupID:     servicePackage.GroupID,
+		QuotaMetric: servicePackage.QuotaMetric,
+	}
+	query := db.
+		Where("user_id = ? AND status IN ?", normalizedUserID, []int{UserPackageSubscriptionStatusActive, UserPackageSubscriptionStatusPending})
+	query = applyUserPackageSubscriptionScopeIdentityFilter(query, probe)
+	rows := make([]UserPackageSubscription, 0)
+	if err := query.Order("expires_at desc, started_at desc, updated_at desc, id desc").Find(&rows).Error; err != nil {
+		return 0, false, err
+	}
+	tailEnd := int64(0)
+	for _, row := range rows {
+		if row.ExpiresAt <= 0 {
+			return 0, true, nil
+		}
+		if row.ExpiresAt > tailEnd {
+			tailEnd = row.ExpiresAt
+		}
+	}
+	return tailEnd, false, nil
+}
+
 func RenewServicePackageForUserWithDB(db *gorm.DB, packageID string, userID string, now int64) (UserPackageSubscription, error) {
 	if db == nil {
 		return UserPackageSubscription{}, fmt.Errorf("database handle is nil")
@@ -311,7 +459,17 @@ func RenewServicePackageForUserWithDB(db *gorm.DB, packageID string, userID stri
 	if err := syncUserPackageSubscriptionsWithDB(db, normalizedUserID, effectiveNow); err != nil {
 		return UserPackageSubscription{}, err
 	}
-	active, err := getActiveUserPackageSubscriptionWithDB(db, normalizedUserID)
+	servicePackage, err := getServicePackageByIDWithDB(db, normalizedPackageID)
+	if err != nil {
+		if errors.Is(err, gorm.ErrRecordNotFound) {
+			return UserPackageSubscription{}, fmt.Errorf("套餐不存在")
+		}
+		return UserPackageSubscription{}, err
+	}
+	if !servicePackage.Enabled {
+		return UserPackageSubscription{}, fmt.Errorf("套餐已禁用")
+	}
+	active, err := getActiveUserPackageSubscriptionForPackageGroupWithDB(db, normalizedUserID, servicePackage, effectiveNow)
 	if err != nil {
 		if errors.Is(err, gorm.ErrRecordNotFound) {
 			return AssignServicePackageToUserWithDB(db, normalizedPackageID, normalizedUserID, effectiveNow)
@@ -324,7 +482,7 @@ func RenewServicePackageForUserWithDB(db *gorm.DB, packageID string, userID stri
 	if active.ExpiresAt <= 0 {
 		return UserPackageSubscription{}, fmt.Errorf("当前生效套餐无到期时间，无法续费")
 	}
-	tailEnd, hasUnlimitedTail, err := latestUserPackageSubscriptionTailWithDB(db, normalizedUserID)
+	tailEnd, hasUnlimitedTail, err := latestUserPackageSubscriptionTailForPackageGroupWithDB(db, normalizedUserID, servicePackage)
 	if err != nil {
 		return UserPackageSubscription{}, err
 	}
@@ -354,30 +512,7 @@ func UpgradeServicePackageForUserWithDB(db *gorm.DB, packageID string, userID st
 	if normalizedUserID == "" {
 		return UserPackageSubscription{}, fmt.Errorf("用户 ID 不能为空")
 	}
-	returnSubscription := UserPackageSubscription{}
-	err := db.Transaction(func(tx *gorm.DB) error {
-		if err := syncUserPackageSubscriptionsWithDB(tx, normalizedUserID, effectiveNow); err != nil {
-			return err
-		}
-		if err := tx.Model(&UserPackageSubscription{}).
-			Where("user_id = ? AND status = ?", normalizedUserID, UserPackageSubscriptionStatusPending).
-			Updates(map[string]any{
-				"status":     UserPackageSubscriptionStatusReplaced,
-				"updated_at": effectiveNow,
-			}).Error; err != nil {
-			return err
-		}
-		row, err := AssignServicePackageToUserWithDB(tx, normalizedPackageID, normalizedUserID, effectiveNow)
-		if err != nil {
-			return err
-		}
-		returnSubscription = row
-		return nil
-	})
-	if err != nil {
-		return UserPackageSubscription{}, err
-	}
-	return returnSubscription, nil
+	return AssignServicePackageToUserWithDB(db, normalizedPackageID, normalizedUserID, effectiveNow)
 }
 
 func GetActiveUserPackageSubscription(userID string) (UserPackageSubscription, error) {
@@ -386,6 +521,44 @@ func GetActiveUserPackageSubscription(userID string) (UserPackageSubscription, e
 
 func GetActiveUserPackageSubscriptionForGroup(userID string, groupID string) (UserPackageSubscription, error) {
 	return getActiveUserPackageSubscriptionForGroupWithDB(DB, userID, groupID)
+}
+
+func GetActiveYYCUserPackageSubscriptionForGroup(userID string, groupID string) (UserPackageSubscription, error) {
+	return getActiveYYCUserPackageSubscriptionForGroupWithDB(DB, userID, groupID)
+}
+
+func listActiveUserPackageSubscriptionsWithDB(db *gorm.DB, userID string) ([]UserPackageSubscription, error) {
+	if db == nil {
+		return nil, fmt.Errorf("database handle is nil")
+	}
+	normalizedUserID := strings.TrimSpace(userID)
+	if normalizedUserID == "" {
+		return nil, fmt.Errorf("用户 ID 不能为空")
+	}
+	now := helper.GetTimestamp()
+	if err := syncUserPackageSubscriptionsWithDB(db, normalizedUserID, now); err != nil {
+		return nil, err
+	}
+	rows := make([]UserPackageSubscription, 0)
+	if err := db.
+		Where("user_id = ? AND status = ? AND started_at <= ? AND (expires_at = 0 OR expires_at > ?)",
+			normalizedUserID,
+			UserPackageSubscriptionStatusActive,
+			now,
+			now,
+		).
+		Order("updated_at desc, started_at desc, id desc").
+		Find(&rows).Error; err != nil {
+		return nil, err
+	}
+	for i := range rows {
+		normalizeServicePackageSubscriptionScopeAndQuota(&rows[i])
+	}
+	return rows, nil
+}
+
+func ListActiveUserPackageSubscriptions(userID string) ([]UserPackageSubscription, error) {
+	return listActiveUserPackageSubscriptionsWithDB(DB, userID)
 }
 
 func ListActiveUserPackageSubscriptionsByUserIDs(userIDs []string) ([]UserPackageSubscription, error) {

--- a/internal/admin/model/user_package_usage_counter.go
+++ b/internal/admin/model/user_package_usage_counter.go
@@ -1,0 +1,480 @@
+package model
+
+import (
+	"errors"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/yeying-community/router/common/helper"
+	"github.com/yeying-community/router/common/random"
+	"gorm.io/gorm"
+	"gorm.io/gorm/clause"
+)
+
+const UserPackageUsageCountersTableName = "user_package_usage_counters"
+
+type UserPackageUsageCounter struct {
+	Id             string `json:"id" gorm:"primaryKey;type:char(36)"`
+	SubscriptionID string `json:"subscription_id" gorm:"type:char(36);not null;uniqueIndex:idx_user_package_usage_unique,priority:1;index"`
+	UserID         string `json:"user_id" gorm:"type:char(36);not null;index"`
+	PackageID      string `json:"package_id" gorm:"type:char(36);not null;index"`
+	GroupID        string `json:"group_id" gorm:"type:char(36);not null;default:'';index"`
+	Metric         string `json:"metric" gorm:"type:varchar(32);not null;uniqueIndex:idx_user_package_usage_unique,priority:2;index"`
+	ScopeType      string `json:"scope_type" gorm:"type:varchar(32);not null;default:'all';uniqueIndex:idx_user_package_usage_unique,priority:3;index"`
+	ScopeProvider  string `json:"scope_provider" gorm:"type:varchar(64);not null;default:'';uniqueIndex:idx_user_package_usage_unique,priority:4;index"`
+	ScopeModel     string `json:"scope_model" gorm:"type:varchar(191);not null;default:'';uniqueIndex:idx_user_package_usage_unique,priority:5;index"`
+	ScopeEndpoint  string `json:"scope_endpoint" gorm:"type:varchar(191);not null;default:'';uniqueIndex:idx_user_package_usage_unique,priority:6"`
+	PeriodType     string `json:"period_type" gorm:"type:varchar(32);not null;default:'none';uniqueIndex:idx_user_package_usage_unique,priority:7;index"`
+	PeriodKey      string `json:"period_key" gorm:"type:varchar(32);not null;default:'';uniqueIndex:idx_user_package_usage_unique,priority:8;index"`
+	LimitAmount    int64  `json:"limit_amount" gorm:"type:bigint;not null;default:0"`
+	ConsumedAmount int64  `json:"consumed_amount" gorm:"type:bigint;not null;default:0"`
+	ReservedAmount int64  `json:"reserved_amount" gorm:"type:bigint;not null;default:0"`
+	CreatedAt      int64  `json:"created_at" gorm:"bigint;index"`
+	UpdatedAt      int64  `json:"updated_at" gorm:"bigint;index"`
+}
+
+func (UserPackageUsageCounter) TableName() string {
+	return UserPackageUsageCountersTableName
+}
+
+func (item *UserPackageUsageCounter) EnsureID() {
+	if item == nil {
+		return
+	}
+	if strings.TrimSpace(item.Id) == "" {
+		item.Id = random.GetUUID()
+	}
+}
+
+type PackageScopeRequest struct {
+	UserID        string
+	GroupID       string
+	RequestAmount int64
+	Now           time.Time
+}
+
+type RequestPackageReservation struct {
+	CounterID      string
+	SubscriptionID string
+	UserID         string
+	PackageID      string
+	GroupID        string
+	Metric         string
+	ScopeType      string
+	ScopeProvider  string
+	ScopeModel     string
+	ScopeEndpoint  string
+	PeriodType     string
+	PeriodKey      string
+	ReservedAmount int64
+	LimitAmount    int64
+}
+
+func (reservation RequestPackageReservation) Active() bool {
+	return strings.TrimSpace(reservation.CounterID) != "" &&
+		strings.TrimSpace(reservation.SubscriptionID) != "" &&
+		reservation.ReservedAmount > 0
+}
+
+type RequestPackageReserveResult struct {
+	Matched      bool
+	Allowed      bool
+	Subscription UserPackageSubscription
+	Reservation  RequestPackageReservation
+	Reason       string
+	Remaining    int64
+}
+
+type RequestPackageUsageSnapshot struct {
+	Metric          string `json:"metric"`
+	PeriodType      string `json:"period_type"`
+	PeriodKey       string `json:"period_key"`
+	LimitAmount     int64  `json:"limit_amount"`
+	ConsumedAmount  int64  `json:"consumed_amount"`
+	ReservedAmount  int64  `json:"reserved_amount"`
+	RemainingAmount int64  `json:"remaining_amount"`
+	Unlimited       bool   `json:"unlimited"`
+	UpdatedAt       int64  `json:"updated_at"`
+}
+
+func normalizePackageScopeRequest(input PackageScopeRequest) PackageScopeRequest {
+	return PackageScopeRequest{
+		UserID:        strings.TrimSpace(input.UserID),
+		GroupID:       strings.TrimSpace(input.GroupID),
+		RequestAmount: maxInt64(input.RequestAmount, 1),
+		Now:           input.Now,
+	}
+}
+
+func requestPackagePeriodKey(periodType string, now time.Time, timezone string) string {
+	if now.IsZero() {
+		now = time.Now()
+	}
+	switch normalizeServicePackagePeriodType(periodType, ServicePackageQuotaMetricRequestCount) {
+	case ServicePackagePeriodDaily:
+		return businessDateByTimezone(now, timezone)
+	case ServicePackagePeriodMonthly:
+		return businessMonthByTimezone(now, timezone)
+	case ServicePackagePeriodPackageTotal:
+		return "total"
+	default:
+		return ""
+	}
+}
+
+func findMatchingRequestPackageSubscriptionsWithDB(db *gorm.DB, req PackageScopeRequest) ([]UserPackageSubscription, error) {
+	if db == nil {
+		return nil, fmt.Errorf("database handle is nil")
+	}
+	if strings.TrimSpace(req.UserID) == "" || strings.TrimSpace(req.GroupID) == "" {
+		return []UserPackageSubscription{}, nil
+	}
+	now := helper.GetTimestamp()
+	if !req.Now.IsZero() {
+		now = req.Now.Unix()
+	}
+	if err := syncUserPackageSubscriptionsWithDB(db, req.UserID, now); err != nil {
+		return nil, err
+	}
+	rows := make([]UserPackageSubscription, 0)
+	query := db.
+		Where("user_id = ? AND status = ? AND started_at <= ? AND (expires_at = 0 OR expires_at > ?)",
+			req.UserID,
+			UserPackageSubscriptionStatusActive,
+			now,
+			now,
+		).
+		Where("package_type = ? AND quota_metric = ? AND group_id = ?",
+			ServicePackageTypeRequestQuota,
+			ServicePackageQuotaMetricRequestCount,
+			req.GroupID,
+		)
+	if err := query.Order("updated_at desc, started_at desc, id desc").Find(&rows).Error; err != nil {
+		return nil, err
+	}
+	matches := make([]UserPackageSubscription, 0, len(rows))
+	for _, row := range rows {
+		normalizeServicePackageSubscriptionScopeAndQuota(&row)
+		matches = append(matches, row)
+	}
+	return matches, nil
+}
+
+func normalizeServicePackageSubscriptionScopeAndQuota(subscription *UserPackageSubscription) {
+	if subscription == nil {
+		return
+	}
+	proxy := ServicePackage{
+		PackageType:              subscription.PackageType,
+		ScopeType:                subscription.ScopeType,
+		ScopeProvider:            subscription.ScopeProvider,
+		ScopeModel:               subscription.ScopeModel,
+		ScopeEndpoint:            subscription.ScopeEndpoint,
+		QuotaMetric:              subscription.QuotaMetric,
+		PeriodType:               subscription.PeriodType,
+		PeriodLimit:              subscription.PeriodLimit,
+		MaxConcurrencyPerUser:    subscription.MaxConcurrencyPerUser,
+		MaxConcurrencyPerPackage: subscription.MaxConcurrencyPerPackage,
+		AllowBalanceFallback:     subscription.AllowBalanceFallback,
+		DailyQuotaLimit:          subscription.DailyQuotaLimit,
+	}
+	normalizeServicePackageScopeAndQuota(&proxy)
+	subscription.PackageType = proxy.PackageType
+	subscription.ScopeType = proxy.ScopeType
+	subscription.ScopeProvider = proxy.ScopeProvider
+	subscription.ScopeModel = proxy.ScopeModel
+	subscription.ScopeEndpoint = proxy.ScopeEndpoint
+	subscription.QuotaMetric = proxy.QuotaMetric
+	subscription.PeriodType = proxy.PeriodType
+	subscription.PeriodLimit = proxy.PeriodLimit
+	subscription.MaxConcurrencyPerUser = proxy.MaxConcurrencyPerUser
+	subscription.MaxConcurrencyPerPackage = proxy.MaxConcurrencyPerPackage
+	subscription.AllowBalanceFallback = proxy.AllowBalanceFallback
+}
+
+func ensureUserPackageUsageCounterWithDB(tx *gorm.DB, subscription UserPackageSubscription, periodKey string) (UserPackageUsageCounter, error) {
+	counter := UserPackageUsageCounter{
+		SubscriptionID: strings.TrimSpace(subscription.Id),
+		UserID:         strings.TrimSpace(subscription.UserID),
+		PackageID:      strings.TrimSpace(subscription.PackageID),
+		GroupID:        strings.TrimSpace(subscription.GroupID),
+		Metric:         strings.TrimSpace(subscription.QuotaMetric),
+		ScopeType:      strings.TrimSpace(subscription.ScopeType),
+		ScopeProvider:  strings.TrimSpace(subscription.ScopeProvider),
+		ScopeModel:     strings.TrimSpace(subscription.ScopeModel),
+		ScopeEndpoint:  strings.TrimSpace(subscription.ScopeEndpoint),
+		PeriodType:     strings.TrimSpace(subscription.PeriodType),
+		PeriodKey:      strings.TrimSpace(periodKey),
+		LimitAmount:    normalizeServicePackagePeriodLimit(subscription.PeriodLimit, subscription.QuotaMetric, subscription.PeriodType, subscription.DailyQuotaLimit),
+		CreatedAt:      helper.GetTimestamp(),
+		UpdatedAt:      helper.GetTimestamp(),
+	}
+	counter.EnsureID()
+	if err := tx.Clauses(clause.OnConflict{DoNothing: true}).Create(&counter).Error; err != nil {
+		return UserPackageUsageCounter{}, err
+	}
+	row := UserPackageUsageCounter{}
+	err := tx.Clauses(clause.Locking{Strength: "UPDATE"}).
+		Where("subscription_id = ? AND metric = ? AND scope_type = ? AND scope_provider = ? AND scope_model = ? AND scope_endpoint = ? AND period_type = ? AND period_key = ?",
+			counter.SubscriptionID,
+			counter.Metric,
+			counter.ScopeType,
+			counter.ScopeProvider,
+			counter.ScopeModel,
+			counter.ScopeEndpoint,
+			counter.PeriodType,
+			counter.PeriodKey,
+		).
+		Take(&row).Error
+	return row, err
+}
+
+func GetRequestPackageUsageSnapshotWithDB(db *gorm.DB, subscription UserPackageSubscription, now time.Time) (RequestPackageUsageSnapshot, error) {
+	if db == nil {
+		return RequestPackageUsageSnapshot{}, fmt.Errorf("database handle is nil")
+	}
+	normalizeServicePackageSubscriptionScopeAndQuota(&subscription)
+	limit := normalizeServicePackagePeriodLimit(subscription.PeriodLimit, subscription.QuotaMetric, subscription.PeriodType, subscription.DailyQuotaLimit)
+	periodKey := requestPackagePeriodKey(subscription.PeriodType, now, subscription.QuotaResetTimezone)
+	snapshot := RequestPackageUsageSnapshot{
+		Metric:      strings.TrimSpace(subscription.QuotaMetric),
+		PeriodType:  strings.TrimSpace(subscription.PeriodType),
+		PeriodKey:   strings.TrimSpace(periodKey),
+		LimitAmount: limit,
+		Unlimited:   limit <= 0,
+	}
+	if strings.TrimSpace(subscription.Id) == "" ||
+		strings.TrimSpace(subscription.QuotaMetric) != ServicePackageQuotaMetricRequestCount {
+		return snapshot, nil
+	}
+	counter := UserPackageUsageCounter{}
+	err := db.
+		Where("subscription_id = ? AND metric = ? AND scope_type = ? AND scope_provider = ? AND scope_model = ? AND scope_endpoint = ? AND period_type = ? AND period_key = ?",
+			strings.TrimSpace(subscription.Id),
+			strings.TrimSpace(subscription.QuotaMetric),
+			strings.TrimSpace(subscription.ScopeType),
+			strings.TrimSpace(subscription.ScopeProvider),
+			strings.TrimSpace(subscription.ScopeModel),
+			strings.TrimSpace(subscription.ScopeEndpoint),
+			strings.TrimSpace(subscription.PeriodType),
+			strings.TrimSpace(periodKey),
+		).
+		Take(&counter).Error
+	if err != nil {
+		if errors.Is(err, gorm.ErrRecordNotFound) {
+			if !snapshot.Unlimited {
+				snapshot.RemainingAmount = limit
+			}
+			return snapshot, nil
+		}
+		return RequestPackageUsageSnapshot{}, err
+	}
+	if counter.LimitAmount > 0 {
+		snapshot.LimitAmount = counter.LimitAmount
+		snapshot.Unlimited = false
+	}
+	snapshot.ConsumedAmount = maxInt64(counter.ConsumedAmount, 0)
+	snapshot.ReservedAmount = maxInt64(counter.ReservedAmount, 0)
+	snapshot.UpdatedAt = counter.UpdatedAt
+	if snapshot.LimitAmount > 0 {
+		snapshot.RemainingAmount = snapshot.LimitAmount - snapshot.ConsumedAmount - snapshot.ReservedAmount
+		if snapshot.RemainingAmount < 0 {
+			snapshot.RemainingAmount = 0
+		}
+	}
+	return snapshot, nil
+}
+
+func GetRequestPackageUsageSnapshot(subscription UserPackageSubscription) (RequestPackageUsageSnapshot, error) {
+	return GetRequestPackageUsageSnapshotWithDB(DB, subscription, time.Now())
+}
+
+func sumReservedRequestPackageByPackageWithDB(tx *gorm.DB, packageID string, periodType string, periodKey string) (int64, error) {
+	total := int64(0)
+	err := tx.Table(UserPackageUsageCountersTableName+" AS c").
+		Joins("JOIN "+UserPackageSubscriptionsTableName+" AS s ON s.id = c.subscription_id").
+		Where("s.package_id = ? AND c.metric = ? AND c.period_type = ? AND c.period_key = ?",
+			strings.TrimSpace(packageID),
+			ServicePackageQuotaMetricRequestCount,
+			strings.TrimSpace(periodType),
+			strings.TrimSpace(periodKey),
+		).
+		Select("COALESCE(SUM(c.reserved_amount), 0)").
+		Scan(&total).Error
+	return total, err
+}
+
+func ReserveRequestPackageWithDB(db *gorm.DB, input PackageScopeRequest) (RequestPackageReserveResult, error) {
+	req := normalizePackageScopeRequest(input)
+	if db == nil {
+		return RequestPackageReserveResult{}, fmt.Errorf("database handle is nil")
+	}
+	if strings.TrimSpace(req.UserID) == "" {
+		return RequestPackageReserveResult{}, fmt.Errorf("用户 ID 不能为空")
+	}
+	matches, err := findMatchingRequestPackageSubscriptionsWithDB(db, req)
+	if err != nil {
+		return RequestPackageReserveResult{}, err
+	}
+	if len(matches) == 0 {
+		return RequestPackageReserveResult{Matched: false, Allowed: false}, nil
+	}
+	var firstDenied RequestPackageReserveResult
+	for _, subscription := range matches {
+		result, err := reserveRequestPackageSubscriptionWithDB(db, subscription, req)
+		if err != nil {
+			return RequestPackageReserveResult{}, err
+		}
+		if result.Allowed {
+			return result, nil
+		}
+		if !firstDenied.Matched {
+			firstDenied = result
+		}
+	}
+	return firstDenied, nil
+}
+
+func reserveRequestPackageSubscriptionWithDB(db *gorm.DB, subscription UserPackageSubscription, req PackageScopeRequest) (RequestPackageReserveResult, error) {
+	normalizeServicePackageSubscriptionScopeAndQuota(&subscription)
+	periodKey := requestPackagePeriodKey(subscription.PeriodType, req.Now, subscription.QuotaResetTimezone)
+	result := RequestPackageReserveResult{
+		Matched:      true,
+		Allowed:      false,
+		Subscription: subscription,
+		Reason:       "request_quota_exhausted",
+	}
+	limit := normalizeServicePackagePeriodLimit(subscription.PeriodLimit, subscription.QuotaMetric, subscription.PeriodType, subscription.DailyQuotaLimit)
+	if limit <= 0 {
+		result.Reason = "request_quota_limit_unconfigured"
+		return result, nil
+	}
+	err := db.Transaction(func(tx *gorm.DB) error {
+		counter, err := ensureUserPackageUsageCounterWithDB(tx, subscription, periodKey)
+		if err != nil {
+			return err
+		}
+		result.Remaining = limit - counter.ConsumedAmount - counter.ReservedAmount
+		if result.Remaining < 0 {
+			result.Remaining = 0
+		}
+		if counter.ConsumedAmount+counter.ReservedAmount+req.RequestAmount > limit {
+			return nil
+		}
+		if subscription.MaxConcurrencyPerUser > 0 && counter.ReservedAmount+req.RequestAmount > int64(subscription.MaxConcurrencyPerUser) {
+			result.Reason = "request_concurrency_per_user_exceeded"
+			return nil
+		}
+		if subscription.MaxConcurrencyPerPackage > 0 {
+			totalReserved, err := sumReservedRequestPackageByPackageWithDB(tx, subscription.PackageID, subscription.PeriodType, periodKey)
+			if err != nil {
+				return err
+			}
+			if totalReserved+req.RequestAmount > int64(subscription.MaxConcurrencyPerPackage) {
+				result.Reason = "request_concurrency_per_package_exceeded"
+				return nil
+			}
+		}
+		updatedAt := helper.GetTimestamp()
+		if err := tx.Model(&UserPackageUsageCounter{}).
+			Where("id = ?", counter.Id).
+			Updates(map[string]any{
+				"reserved_amount": gorm.Expr("reserved_amount + ?", req.RequestAmount),
+				"limit_amount":    limit,
+				"updated_at":      updatedAt,
+			}).Error; err != nil {
+			return err
+		}
+		result.Allowed = true
+		result.Reason = ""
+		result.Remaining = limit - counter.ConsumedAmount - counter.ReservedAmount - req.RequestAmount
+		if result.Remaining < 0 {
+			result.Remaining = 0
+		}
+		result.Reservation = RequestPackageReservation{
+			CounterID:      counter.Id,
+			SubscriptionID: strings.TrimSpace(subscription.Id),
+			UserID:         strings.TrimSpace(subscription.UserID),
+			PackageID:      strings.TrimSpace(subscription.PackageID),
+			GroupID:        strings.TrimSpace(subscription.GroupID),
+			Metric:         strings.TrimSpace(subscription.QuotaMetric),
+			ScopeType:      strings.TrimSpace(subscription.ScopeType),
+			ScopeProvider:  strings.TrimSpace(subscription.ScopeProvider),
+			ScopeModel:     strings.TrimSpace(subscription.ScopeModel),
+			ScopeEndpoint:  strings.TrimSpace(subscription.ScopeEndpoint),
+			PeriodType:     strings.TrimSpace(subscription.PeriodType),
+			PeriodKey:      strings.TrimSpace(periodKey),
+			ReservedAmount: req.RequestAmount,
+			LimitAmount:    limit,
+		}
+		return nil
+	})
+	return result, err
+}
+
+func ReserveRequestPackage(input PackageScopeRequest) (RequestPackageReserveResult, error) {
+	return ReserveRequestPackageWithDB(DB, input)
+}
+
+func ReleaseRequestPackageReservationWithDB(db *gorm.DB, reservation RequestPackageReservation) error {
+	if db == nil {
+		return fmt.Errorf("database handle is nil")
+	}
+	if !reservation.Active() {
+		return nil
+	}
+	return db.Model(&UserPackageUsageCounter{}).
+		Where("id = ?", strings.TrimSpace(reservation.CounterID)).
+		Updates(map[string]any{
+			"reserved_amount": gorm.Expr("CASE WHEN reserved_amount >= ? THEN reserved_amount - ? ELSE 0 END", reservation.ReservedAmount, reservation.ReservedAmount),
+			"updated_at":      helper.GetTimestamp(),
+		}).Error
+}
+
+func ReleaseRequestPackageReservation(reservation RequestPackageReservation) error {
+	return ReleaseRequestPackageReservationWithDB(DB, reservation)
+}
+
+func SettleRequestPackageReservationWithDB(db *gorm.DB, reservation RequestPackageReservation, consumedAmount int64) (int64, error) {
+	if db == nil {
+		return 0, fmt.Errorf("database handle is nil")
+	}
+	if !reservation.Active() {
+		return 0, nil
+	}
+	consumed := consumedAmount
+	if consumed < 0 {
+		consumed = 0
+	}
+	if consumed == 0 {
+		consumed = reservation.ReservedAmount
+	}
+	var settled int64
+	err := db.Transaction(func(tx *gorm.DB) error {
+		counter := UserPackageUsageCounter{}
+		if err := tx.Clauses(clause.Locking{Strength: "UPDATE"}).
+			Where("id = ?", strings.TrimSpace(reservation.CounterID)).
+			Take(&counter).Error; err != nil {
+			return err
+		}
+		headroom := reservation.LimitAmount - counter.ConsumedAmount
+		if headroom < 0 {
+			headroom = 0
+		}
+		settled = minInt64(consumed, headroom)
+		return tx.Model(&UserPackageUsageCounter{}).
+			Where("id = ?", counter.Id).
+			Updates(map[string]any{
+				"reserved_amount": gorm.Expr("CASE WHEN reserved_amount >= ? THEN reserved_amount - ? ELSE 0 END", reservation.ReservedAmount, reservation.ReservedAmount),
+				"consumed_amount": gorm.Expr("consumed_amount + ?", settled),
+				"limit_amount":    reservation.LimitAmount,
+				"updated_at":      helper.GetTimestamp(),
+			}).Error
+	})
+	return settled, err
+}
+
+func SettleRequestPackageReservation(reservation RequestPackageReservation, consumedAmount int64) (int64, error) {
+	return SettleRequestPackageReservationWithDB(DB, reservation, consumedAmount)
+}

--- a/internal/admin/model/user_quota_counter.go
+++ b/internal/admin/model/user_quota_counter.go
@@ -236,7 +236,7 @@ func ReservePackageQuotaWithDB(db *gorm.DB, groupID string, userID string, quota
 	if normalizedUserID == "" {
 		return PackageQuotaReservation{}, false, fmt.Errorf("用户 ID 不能为空")
 	}
-	subscription, err := getActiveUserPackageSubscriptionForGroupWithDB(db, normalizedUserID, normalizedGroupID)
+	subscription, err := getActiveYYCUserPackageSubscriptionForGroupWithDB(db, normalizedUserID, normalizedGroupID)
 	if err != nil {
 		if err == gorm.ErrRecordNotFound {
 			return PackageQuotaReservation{}, true, nil

--- a/internal/relay/billing/billing.go
+++ b/internal/relay/billing/billing.go
@@ -40,10 +40,10 @@ func ReturnPreConsumedQuota(ctx context.Context, preConsumedQuota int64, tokenId
 
 type LogRouteObserver func(entry *model.Log)
 
-func PostConsumeQuota(ctx context.Context, tokenId string, quotaDelta int64, totalQuota int64, userId string, groupID string, channelId string, pricing model.ResolvedModelPricing, groupRatio float64, modelName string, tokenName string, chargeUserBalance bool, packageReservation model.PackageQuotaReservation, snapshot BillingSnapshot, routeObservers ...LogRouteObserver) {
+func PostConsumeQuota(ctx context.Context, tokenId string, quotaDelta int64, totalQuota int64, userId string, groupID string, channelId string, pricing model.ResolvedModelPricing, groupRatio float64, modelName string, tokenName string, chargeUserBalance bool, chargeTokenQuota bool, packageReservation model.PackageQuotaReservation, snapshot BillingSnapshot, routeObservers ...LogRouteObserver) {
 	// quotaDelta is remaining quota to be consumed
 	var err error
-	if strings.TrimSpace(tokenId) != "" {
+	if strings.TrimSpace(tokenId) != "" && chargeTokenQuota {
 		if chargeUserBalance {
 			err = model.PostConsumeTokenQuota(tokenId, quotaDelta)
 		} else {

--- a/internal/relay/controller/audio.go
+++ b/internal/relay/controller/audio.go
@@ -95,15 +95,14 @@ func RelayAudioHelper(c *gin.Context, relayMode int) *relaymodel.ErrorWithStatus
 		}
 		preConsumedQuota = billingSnapshot.ChargeAmount
 	}
-	billingPlan, quotaErr := reserveRelayQuota(ctx, group, userId, preConsumedQuota)
+	billingPlan, quotaErr := reserveRelayQuota(ctx, meta, preConsumedQuota)
 	if quotaErr != nil {
 		return quotaErr
 	}
-	packageReservation := billingPlan.PackageReservation
 	groupQuotaSettled := false
 	defer func() {
 		if !groupQuotaSettled {
-			releasePackageQuotaReservation(ctx, packageReservation)
+			releaseRelayBillingPlan(ctx, billingPlan)
 		}
 	}()
 	if billingPlan.ChargeUserBalance() {
@@ -141,7 +140,7 @@ func RelayAudioHelper(c *gin.Context, relayMode int) *relaymodel.ErrorWithStatus
 				}
 			}
 		}
-	} else if preConsumedQuota > 0 && strings.TrimSpace(tokenId) != "" {
+	} else if preConsumedQuota > 0 && strings.TrimSpace(tokenId) != "" && billingPlan.ChargeTokenQuota() {
 		if err := model.PreConsumeTokenRemainQuota(tokenId, preConsumedQuota); err != nil {
 			return openai.ErrorWrapper(err, "pre_consume_token_quota_failed", http.StatusForbidden)
 		}
@@ -152,7 +151,7 @@ func RelayAudioHelper(c *gin.Context, relayMode int) *relaymodel.ErrorWithStatus
 			return
 		}
 		if preConsumedQuota > 0 {
-			billing.ReturnPreConsumedQuota(c.Request.Context(), preConsumedQuota, tokenId, userId, billingPlan.ChargeUserBalance())
+			billing.ReturnPreConsumedQuota(c.Request.Context(), preConsumedQuota, tokenId, userId, billingPlan.ChargeUserBalance() && billingPlan.ChargeTokenQuota())
 		}
 	}()
 
@@ -282,12 +281,16 @@ func RelayAudioHelper(c *gin.Context, relayMode int) *relaymodel.ErrorWithStatus
 			audioModel,
 			tokenName,
 			billingPlan.ChargeUserBalance(),
-			packageReservation,
+			billingPlan.ChargeTokenQuota(),
+			billingPlan.PackageReservation,
 			billingSnapshot,
 			func(entry *model.Log) {
 				applyRouteObservabilityToLog(entry, meta, audioModel)
 			},
 		)
+		if billingPlan.UsesRequestPackage() {
+			settleRelayBillingPlan(ctx, billingPlan, quota)
+		}
 	}(c.Request.Context())
 	groupQuotaSettled = true
 

--- a/internal/relay/controller/billing_mode.go
+++ b/internal/relay/controller/billing_mode.go
@@ -3,12 +3,14 @@ package controller
 import (
 	"context"
 	"errors"
+	"fmt"
 	"net/http"
 	"strings"
 
 	"github.com/yeying-community/router/common/logger"
 	"github.com/yeying-community/router/internal/admin/model"
 	"github.com/yeying-community/router/internal/relay/adaptor/openai"
+	"github.com/yeying-community/router/internal/relay/meta"
 	relaymodel "github.com/yeying-community/router/internal/relay/model"
 	"gorm.io/gorm"
 )
@@ -22,12 +24,25 @@ const (
 )
 
 type relayBillingPlan struct {
-	Source             relayBillingSource
-	PackageReservation model.PackageQuotaReservation
+	Source                    relayBillingSource
+	PackageReservation        model.PackageQuotaReservation
+	RequestPackageReservation model.RequestPackageReservation
 }
 
 func (plan relayBillingPlan) ChargeUserBalance() bool {
 	return plan.Source != relayBillingSourcePackage
+}
+
+func (plan relayBillingPlan) UsesPackage() bool {
+	return plan.Source == relayBillingSourcePackage
+}
+
+func (plan relayBillingPlan) UsesRequestPackage() bool {
+	return plan.RequestPackageReservation.Active()
+}
+
+func (plan relayBillingPlan) ChargeTokenQuota() bool {
+	return !plan.UsesRequestPackage()
 }
 
 func buildBalanceRelayBillingPlan(packageActive bool) relayBillingPlan {
@@ -38,13 +53,17 @@ func buildBalanceRelayBillingPlan(packageActive bool) relayBillingPlan {
 	return relayBillingPlan{Source: source}
 }
 
+func tryBuildRequestPackageBillingPlan(ctx context.Context, meta *meta.Meta) (relayBillingPlan, bool, *relaymodel.ErrorWithStatusCode) {
+	return tryReserveRequestPackage(ctx, meta)
+}
+
 func hasActivePackageForGroup(userID string, groupID string) (bool, error) {
 	normalizedUserID := strings.TrimSpace(userID)
 	normalizedGroupID := strings.TrimSpace(groupID)
 	if normalizedUserID == "" || normalizedGroupID == "" {
 		return false, nil
 	}
-	_, err := model.GetActiveUserPackageSubscriptionForGroup(normalizedUserID, normalizedGroupID)
+	_, err := model.GetActiveYYCUserPackageSubscriptionForGroup(normalizedUserID, normalizedGroupID)
 	if err == nil {
 		return true, nil
 	}
@@ -54,7 +73,67 @@ func hasActivePackageForGroup(userID string, groupID string) (bool, error) {
 	return false, err
 }
 
-func reserveRelayQuota(ctx context.Context, groupID string, userID string, quota int64) (relayBillingPlan, *relaymodel.ErrorWithStatusCode) {
+func formatRequestPackageDeniedMessage(result model.RequestPackageReserveResult) string {
+	packageName := strings.TrimSpace(result.Subscription.PackageName)
+	if packageName == "" {
+		packageName = strings.TrimSpace(result.Subscription.PackageID)
+	}
+	if packageName == "" {
+		packageName = "当前套餐"
+	}
+	switch strings.TrimSpace(result.Reason) {
+	case "request_concurrency_per_user_exceeded":
+		return fmt.Sprintf("%s 当前用户并发请求数已达上限", packageName)
+	case "request_concurrency_per_package_exceeded":
+		return fmt.Sprintf("%s 当前套餐总并发请求数已达上限", packageName)
+	case "request_quota_limit_unconfigured":
+		return fmt.Sprintf("%s 请求次数额度未配置", packageName)
+	default:
+		return fmt.Sprintf("%s 请求次数额度不足，本周期剩余 %d 次", packageName, result.Remaining)
+	}
+}
+
+func tryReserveRequestPackage(ctx context.Context, meta *meta.Meta) (relayBillingPlan, bool, *relaymodel.ErrorWithStatusCode) {
+	if meta == nil || strings.TrimSpace(meta.UserId) == "" {
+		return relayBillingPlan{}, false, nil
+	}
+	result, err := model.ReserveRequestPackage(model.PackageScopeRequest{
+		UserID:        meta.UserId,
+		GroupID:       meta.Group,
+		RequestAmount: 1,
+	})
+	if err != nil {
+		logger.Errorf(ctx, "request package reserve failed code=reserve_request_package_failed user_id=%s group=%s err=%q", strings.TrimSpace(meta.UserId), strings.TrimSpace(meta.Group), err.Error())
+		return relayBillingPlan{}, true, openai.ErrorWrapper(err, "reserve_request_package_failed", http.StatusInternalServerError)
+	}
+	if !result.Matched {
+		return relayBillingPlan{}, false, nil
+	}
+	if !result.Allowed {
+		if result.Subscription.AllowBalanceFallback {
+			logger.Infof(ctx, "request package denied with balance fallback user_id=%s group=%s package_id=%s reason=%s remaining=%d", strings.TrimSpace(meta.UserId), strings.TrimSpace(meta.Group), strings.TrimSpace(result.Subscription.PackageID), strings.TrimSpace(result.Reason), result.Remaining)
+			return buildBalanceRelayBillingPlan(true), true, nil
+		}
+		message := formatRequestPackageDeniedMessage(result)
+		logger.Warnf(ctx, "request package denied user_id=%s group=%s package_id=%s reason=%s remaining=%d", strings.TrimSpace(meta.UserId), strings.TrimSpace(meta.Group), strings.TrimSpace(result.Subscription.PackageID), strings.TrimSpace(result.Reason), result.Remaining)
+		return relayBillingPlan{}, true, openai.ErrorWrapper(errors.New(message), "request_package_quota_exceeded", http.StatusForbidden)
+	}
+	return relayBillingPlan{
+		Source:                    relayBillingSourcePackage,
+		RequestPackageReservation: result.Reservation,
+	}, true, nil
+}
+
+func reserveRelayQuota(ctx context.Context, meta *meta.Meta, quota int64) (relayBillingPlan, *relaymodel.ErrorWithStatusCode) {
+	if plan, matched, err := tryReserveRequestPackage(ctx, meta); matched || err != nil {
+		return plan, err
+	}
+	groupID := ""
+	userID := ""
+	if meta != nil {
+		groupID = meta.Group
+		userID = meta.UserId
+	}
 	packageActive, err := hasActivePackageForGroup(userID, groupID)
 	if err != nil {
 		return relayBillingPlan{}, openai.ErrorWrapper(err, "resolve_billing_source_failed", http.StatusInternalServerError)

--- a/internal/relay/controller/billing_mode_test.go
+++ b/internal/relay/controller/billing_mode_test.go
@@ -1,6 +1,14 @@
 package controller
 
-import "testing"
+import (
+	"context"
+	"testing"
+
+	adminmodel "github.com/yeying-community/router/internal/admin/model"
+	relaymeta "github.com/yeying-community/router/internal/relay/meta"
+	"gorm.io/driver/sqlite"
+	"gorm.io/gorm"
+)
 
 func TestBuildBalanceRelayBillingPlanWithoutPackage(t *testing.T) {
 	plan := buildBalanceRelayBillingPlan(false)
@@ -19,5 +27,84 @@ func TestBuildBalanceRelayBillingPlanWithPackageFallback(t *testing.T) {
 	}
 	if !plan.ChargeUserBalance() {
 		t.Fatalf("plan.ChargeUserBalance() = false, want true")
+	}
+}
+
+func TestRelayBillingPlanWithRequestPackageDoesNotChargeTokenQuota(t *testing.T) {
+	plan := relayBillingPlan{
+		Source: relayBillingSourcePackage,
+		RequestPackageReservation: adminmodel.RequestPackageReservation{
+			CounterID:      "counter-1",
+			SubscriptionID: "subscription-1",
+			ReservedAmount: 1,
+		},
+	}
+	if plan.ChargeUserBalance() {
+		t.Fatalf("plan.ChargeUserBalance() = true, want false")
+	}
+	if !plan.UsesRequestPackage() {
+		t.Fatalf("plan.UsesRequestPackage() = false, want true")
+	}
+	if plan.ChargeTokenQuota() {
+		t.Fatalf("plan.ChargeTokenQuota() = true, want false")
+	}
+}
+
+func TestTryBuildRequestPackageBillingPlanMatchesGroupBeforePricing(t *testing.T) {
+	db, err := gorm.Open(sqlite.Open("file:"+t.Name()+"?mode=memory&cache=private"), &gorm.Config{})
+	if err != nil {
+		t.Fatalf("open sqlite: %v", err)
+	}
+	if err := db.AutoMigrate(
+		&adminmodel.User{},
+		&adminmodel.GroupCatalog{},
+		&adminmodel.ServicePackage{},
+		&adminmodel.ServicePackageVisibleUser{},
+		&adminmodel.UserPackageSubscription{},
+		&adminmodel.UserPackageUsageCounter{},
+	); err != nil {
+		t.Fatalf("AutoMigrate: %v", err)
+	}
+	previousDB := adminmodel.DB
+	adminmodel.DB = db
+	t.Cleanup(func() {
+		adminmodel.DB = previousDB
+	})
+	if err := db.Create(&adminmodel.GroupCatalog{Id: "group-1", Name: "request package group", Enabled: true}).Error; err != nil {
+		t.Fatalf("seed group: %v", err)
+	}
+	if err := db.Create(&adminmodel.User{Id: "user-1", Username: "user1", Password: "password123", Status: adminmodel.UserStatusEnabled}).Error; err != nil {
+		t.Fatalf("seed user: %v", err)
+	}
+	servicePackage, err := adminmodel.CreateServicePackage(adminmodel.ServicePackage{
+		Name:        "request monthly",
+		GroupID:     "group-1",
+		PackageType: adminmodel.ServicePackageTypeRequestQuota,
+		QuotaMetric: adminmodel.ServicePackageQuotaMetricRequestCount,
+		PeriodLimit: 25000,
+		Enabled:     true,
+	})
+	if err != nil {
+		t.Fatalf("CreateServicePackage returned error: %v", err)
+	}
+	if _, err := adminmodel.AssignServicePackageToUser(servicePackage.Id, "user-1", 0); err != nil {
+		t.Fatalf("AssignServicePackageToUser returned error: %v", err)
+	}
+
+	plan, matched, relayErr := tryBuildRequestPackageBillingPlan(context.Background(), &relaymeta.Meta{
+		UserId: "user-1",
+		Group:  "group-1",
+	})
+	if relayErr != nil {
+		t.Fatalf("tryBuildRequestPackageBillingPlan returned error: %+v", relayErr)
+	}
+	if !matched {
+		t.Fatalf("matched=false, want true")
+	}
+	if !plan.UsesRequestPackage() || plan.ChargeTokenQuota() || plan.ChargeUserBalance() {
+		t.Fatalf("request package plan mismatch: %+v", plan)
+	}
+	if !plan.RequestPackageReservation.Active() {
+		t.Fatalf("request package reservation inactive: %+v", plan.RequestPackageReservation)
 	}
 }

--- a/internal/relay/controller/group_quota.go
+++ b/internal/relay/controller/group_quota.go
@@ -95,6 +95,15 @@ func releasePackageQuotaReservation(ctx context.Context, reservation model.Packa
 	}
 }
 
+func releaseRelayBillingPlan(ctx context.Context, plan relayBillingPlan) {
+	releasePackageQuotaReservation(ctx, plan.PackageReservation)
+	if plan.RequestPackageReservation.Active() {
+		if err := model.ReleaseRequestPackageReservation(plan.RequestPackageReservation); err != nil {
+			logger.Errorf(ctx, "request package release failed code=release_request_package_reservation_failed user_id=%s subscription_id=%s counter_id=%s reserved=%d err=%q", strings.TrimSpace(plan.RequestPackageReservation.UserID), strings.TrimSpace(plan.RequestPackageReservation.SubscriptionID), strings.TrimSpace(plan.RequestPackageReservation.CounterID), plan.RequestPackageReservation.ReservedAmount, err.Error())
+		}
+	}
+}
+
 func settlePackageQuotaReservation(ctx context.Context, reservation model.PackageQuotaReservation, consumedQuota int64) (int64, int64) {
 	if !reservation.Active() {
 		return 0, 0
@@ -105,6 +114,17 @@ func settlePackageQuotaReservation(ctx context.Context, reservation model.Packag
 		return 0, 0
 	}
 	return dailyConsumed, emergencyConsumed
+}
+
+func settleRelayBillingPlan(ctx context.Context, plan relayBillingPlan, consumedQuota int64) (int64, int64) {
+	if plan.RequestPackageReservation.Active() {
+		_, err := model.SettleRequestPackageReservation(plan.RequestPackageReservation, 1)
+		if err != nil {
+			logger.Errorf(ctx, "request package settle failed code=settle_request_package_reservation_failed user_id=%s subscription_id=%s counter_id=%s err=%q", strings.TrimSpace(plan.RequestPackageReservation.UserID), strings.TrimSpace(plan.RequestPackageReservation.SubscriptionID), strings.TrimSpace(plan.RequestPackageReservation.CounterID), err.Error())
+		}
+		return 0, 0
+	}
+	return settlePackageQuotaReservation(ctx, plan.PackageReservation, consumedQuota)
 }
 
 func IsGroupDailyQuotaExceededError(err *relaymodel.ErrorWithStatusCode) bool {

--- a/internal/relay/controller/helper.go
+++ b/internal/relay/controller/helper.go
@@ -71,9 +71,14 @@ func getPreConsumedQuota(textRequest *relaymodel.GeneralOpenAIRequest, promptTok
 	return int64(float64(preConsumedTokens) * ratio)
 }
 
-func preConsumeQuota(ctx context.Context, preConsumedQuota int64, meta *meta.Meta, chargeUserBalance bool) (int64, *relaymodel.ErrorWithStatusCode) {
+func preConsumeQuota(ctx context.Context, preConsumedQuota int64, meta *meta.Meta, billingPlan relayBillingPlan) (int64, *relaymodel.ErrorWithStatusCode) {
 	var err error
+	chargeUserBalance := billingPlan.ChargeUserBalance()
+	chargeTokenQuota := billingPlan.ChargeTokenQuota()
 	if !chargeUserBalance {
+		if !chargeTokenQuota {
+			return 0, nil
+		}
 		if strings.TrimSpace(meta.TokenId) == "" {
 			return 0, nil
 		}
@@ -176,12 +181,14 @@ func logTokenPreConsumeFailure(ctx context.Context, meta *meta.Meta, quota int64
 	)
 }
 
-func postConsumeQuota(ctx context.Context, usage *relaymodel.Usage, meta *meta.Meta, textRequest *relaymodel.GeneralOpenAIRequest, pricing model.ResolvedModelPricing, preConsumedQuota int64, groupRatio float64, estimateResult tokenestimate.EstimateResult, responsesImageTools []responsesImageToolSpec, systemPromptReset bool, chargeUserBalance bool, packageReservation model.PackageQuotaReservation) {
+func postConsumeQuota(ctx context.Context, usage *relaymodel.Usage, meta *meta.Meta, textRequest *relaymodel.GeneralOpenAIRequest, pricing model.ResolvedModelPricing, preConsumedQuota int64, groupRatio float64, estimateResult tokenestimate.EstimateResult, responsesImageTools []responsesImageToolSpec, systemPromptReset bool, billingPlan relayBillingPlan) {
 	if usage == nil {
 		logger.Error(ctx, "usage is nil, which is unexpected")
-		releasePackageQuotaReservation(ctx, packageReservation)
+		releaseRelayBillingPlan(ctx, billingPlan)
 		return
 	}
+	chargeUserBalance := billingPlan.ChargeUserBalance()
+	chargeTokenQuota := billingPlan.ChargeTokenQuota()
 	promptTokens := usage.PromptTokens
 	completionTokens := usage.CompletionTokens
 	quota := preConsumedQuota
@@ -209,7 +216,7 @@ func postConsumeQuota(ctx context.Context, usage *relaymodel.Usage, meta *meta.M
 	}
 	var err error
 	quotaDelta := quota - preConsumedQuota
-	if strings.TrimSpace(meta.TokenId) != "" {
+	if strings.TrimSpace(meta.TokenId) != "" && chargeTokenQuota {
 		if chargeUserBalance {
 			err = model.PostConsumeTokenQuota(meta.TokenId, quotaDelta)
 		} else {
@@ -245,7 +252,7 @@ func postConsumeQuota(ctx context.Context, usage *relaymodel.Usage, meta *meta.M
 	userDailyQuota := 0
 	userEmergencyQuota := 0
 	if !chargeUserBalance {
-		dailyConsumed, emergencyConsumed := settlePackageQuotaReservation(ctx, packageReservation, quota)
+		dailyConsumed, emergencyConsumed := settleRelayBillingPlan(ctx, billingPlan, quota)
 		userDailyQuota = int(dailyConsumed)
 		userEmergencyQuota = int(emergencyConsumed)
 	}
@@ -274,6 +281,34 @@ func postConsumeQuota(ctx context.Context, usage *relaymodel.Usage, meta *meta.M
 	billing.RecordProcurementConsumptionObservation(ctx, entry)
 	model.UpdateUserUsedQuotaAndRequestCount(meta.UserId, quota)
 	model.UpdateChannelUsedQuota(meta.ChannelId, quota)
+}
+
+func settleRequestPackageOnlyConsumption(ctx context.Context, meta *meta.Meta, modelName string, tokenName string, promptTokens int, completionTokens int, elapsedTime int64, isStream bool, billingPlan relayBillingPlan) {
+	if !billingPlan.UsesRequestPackage() {
+		return
+	}
+	settleRelayBillingPlan(ctx, billingPlan, 0)
+	entry := &model.Log{
+		UserId:                meta.UserId,
+		GroupId:               meta.Group,
+		ChannelId:             meta.ChannelId,
+		PromptTokens:          promptTokens,
+		CompletionTokens:      completionTokens,
+		ModelName:             strings.TrimSpace(modelName),
+		TokenName:             strings.TrimSpace(tokenName),
+		Quota:                 0,
+		BillingSource:         model.LogBillingSourcePackage,
+		Content:               "request_count package",
+		IsStream:              isStream,
+		ElapsedTime:           elapsedTime,
+		BillingUsageSource:    billingUsageSourceUpstreamUsage,
+		BillingSettlementMode: "request_count_final",
+		BillingChargeAmount:   0,
+	}
+	applyRouteObservabilityToLog(entry, meta, modelName)
+	model.RecordConsumeLog(ctx, entry)
+	model.UpdateUserUsedQuotaAndRequestCount(meta.UserId, 0)
+	model.UpdateChannelUsedQuota(meta.ChannelId, 0)
 }
 
 func getMappedModelName(modelName string, mapping map[string]string) (string, bool) {

--- a/internal/relay/controller/image.go
+++ b/internal/relay/controller/image.go
@@ -21,6 +21,7 @@ import (
 
 	"github.com/yeying-community/router/common"
 	"github.com/yeying-community/router/common/ctxkey"
+	"github.com/yeying-community/router/common/helper"
 	"github.com/yeying-community/router/common/logger"
 	"github.com/yeying-community/router/internal/admin/model"
 	adminmodel "github.com/yeying-community/router/internal/admin/model"
@@ -686,6 +687,34 @@ func RelayImageHelper(c *gin.Context, relayMode int) *relaymodel.ErrorWithStatus
 		}
 	}
 
+	if requestPackagePlan, matched, quotaErr := tryBuildRequestPackageBillingPlan(ctx, meta); quotaErr != nil || (matched && requestPackagePlan.UsesRequestPackage()) {
+		if quotaErr != nil {
+			return quotaErr
+		}
+		groupQuotaSettled := false
+		defer func() {
+			if !groupQuotaSettled {
+				releaseRelayBillingPlan(ctx, requestPackagePlan)
+			}
+		}()
+		resp, err := adaptor.DoRequest(c, meta, requestBody)
+		if err != nil {
+			return openai.ErrorWrapper(err, classifyImageRequestErrorCode(err), http.StatusInternalServerError)
+		}
+		if resp != nil &&
+			resp.StatusCode != http.StatusCreated &&
+			resp.StatusCode != http.StatusOK {
+			return RelayErrorHandler(meta, resp)
+		}
+		if _, respErr := adaptor.DoResponse(c, resp, meta); respErr != nil {
+			logger.Errorf(ctx, "image request package response failed user_id=%s group=%s channel_id=%s model=%s endpoint=%s err=%+v", strings.TrimSpace(meta.UserId), strings.TrimSpace(meta.Group), strings.TrimSpace(meta.ChannelId), strings.TrimSpace(imageRequest.Model), c.Request.URL.Path, respErr)
+			return respErr
+		}
+		go settleRequestPackageOnlyConsumption(ctx, meta, imageRequest.Model, c.GetString(ctxkey.TokenName), 0, 0, helper.CalcElapsedTime(meta.StartTime), false, requestPackagePlan)
+		groupQuotaSettled = true
+		return nil
+	}
+
 	imageCount := imageRequest.N
 	if meta.ChannelProtocol == relaychannel.Replicate {
 		imageCount = 1
@@ -819,15 +848,14 @@ func RelayImageHelper(c *gin.Context, relayMode int) *relaymodel.ErrorWithStatus
 		return openai.ErrorWrapper(err, "calculate_image_quota_failed", http.StatusInternalServerError)
 	}
 	quota := billingSnapshot.ChargeAmount
-	billingPlan, quotaErr := reserveRelayQuota(ctx, meta.Group, meta.UserId, quota)
+	billingPlan, quotaErr := reserveRelayQuota(ctx, meta, quota)
 	if quotaErr != nil {
 		return quotaErr
 	}
-	packageReservation := billingPlan.PackageReservation
 	groupQuotaSettled := false
 	defer func() {
 		if !groupQuotaSettled {
-			releasePackageQuotaReservation(ctx, packageReservation)
+			releaseRelayBillingPlan(ctx, billingPlan)
 		}
 	}()
 
@@ -855,22 +883,22 @@ func RelayImageHelper(c *gin.Context, relayMode int) *relaymodel.ErrorWithStatus
 		if resp != nil &&
 			resp.StatusCode != http.StatusCreated && // replicate returns 201
 			resp.StatusCode != http.StatusOK {
-			releasePackageQuotaReservation(ctx, packageReservation)
+			releaseRelayBillingPlan(ctx, billingPlan)
 			return
 		}
 		if !responseSettled {
-			releasePackageQuotaReservation(ctx, packageReservation)
+			releaseRelayBillingPlan(ctx, billingPlan)
 			return
 		}
 		userDailyQuota := 0
 		userEmergencyQuota := 0
 		if !billingPlan.ChargeUserBalance() {
-			dailyConsumed, emergencyConsumed := settlePackageQuotaReservation(ctx, packageReservation, quota)
+			dailyConsumed, emergencyConsumed := settleRelayBillingPlan(ctx, billingPlan, quota)
 			userDailyQuota = int(dailyConsumed)
 			userEmergencyQuota = int(emergencyConsumed)
 		}
 
-		if strings.TrimSpace(meta.TokenId) != "" {
+		if strings.TrimSpace(meta.TokenId) != "" && billingPlan.ChargeTokenQuota() {
 			if billingPlan.ChargeUserBalance() {
 				err := model.PostConsumeTokenQuota(meta.TokenId, quota)
 				if err != nil {

--- a/internal/relay/controller/text.go
+++ b/internal/relay/controller/text.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/yeying-community/router/common"
 	"github.com/yeying-community/router/common/config"
+	"github.com/yeying-community/router/common/helper"
 	"github.com/yeying-community/router/common/logger"
 	adminmodel "github.com/yeying-community/router/internal/admin/model"
 	"github.com/yeying-community/router/internal/relay"
@@ -94,6 +95,63 @@ func RelayTextHelper(c *gin.Context) *model.ErrorWithStatusCode {
 			strings.TrimSpace(meta.ActualModelName),
 		)
 	}
+	if requestPackagePlan, matched, quotaErr := tryBuildRequestPackageBillingPlan(ctx, meta); quotaErr != nil || (matched && requestPackagePlan.UsesRequestPackage()) {
+		if quotaErr != nil {
+			return quotaErr
+		}
+		groupQuotaSettled := false
+		defer func() {
+			if !groupQuotaSettled {
+				releaseRelayBillingPlan(ctx, requestPackagePlan)
+			}
+		}()
+		rawRequestBody := validatedRawBody
+		if len(rawRequestBody) == 0 {
+			var rawBodyErr error
+			rawRequestBody, rawBodyErr = common.GetRequestBody(c)
+			if rawBodyErr != nil {
+				logger.Errorf(ctx, "get request body for request package text relay failed: %s", rawBodyErr.Error())
+				return openai.ErrorWrapper(rawBodyErr, "read_request_body_failed", http.StatusBadRequest)
+			}
+		}
+		upstreamRequest, err := convertTextRequestForUpstream(textRequest, meta.Mode, upstreamMode)
+		if err != nil {
+			return openai.ErrorWrapper(err, "convert_request_failed", http.StatusBadRequest)
+		}
+		adaptor := relay.GetAdaptor(meta.APIType)
+		if adaptor == nil {
+			return openai.ErrorWrapper(fmt.Errorf("invalid api type: %d", meta.APIType), "invalid_api_type", http.StatusBadRequest)
+		}
+		adaptor.Init(meta)
+		requestBody, err := getRequestBody(c, meta, upstreamRequest, adaptor, rawRequestBody)
+		if err != nil {
+			var policyErr *endpointPolicyError
+			if errors.As(err, &policyErr) {
+				return openai.ErrorWrapper(policyErr, policyErr.ErrorCode(), policyErr.StatusCode())
+			}
+			return openai.ErrorWrapper(err, "convert_request_failed", http.StatusInternalServerError)
+		}
+		resp, err := adaptor.DoRequest(c, meta, requestBody)
+		if err != nil {
+			return openai.ErrorWrapper(err, "do_request_failed", http.StatusInternalServerError)
+		}
+		if isErrorHappened(meta, resp) {
+			return RelayErrorHandler(meta, resp)
+		}
+		usage, respErr := adaptor.DoResponse(c, resp, meta)
+		if respErr != nil {
+			return respErr
+		}
+		promptTokens := 0
+		completionTokens := 0
+		if usage != nil {
+			promptTokens = usage.PromptTokens
+			completionTokens = usage.CompletionTokens
+		}
+		go settleRequestPackageOnlyConsumption(ctx, meta, upstreamRequest.Model, meta.TokenName, promptTokens, completionTokens, helper.CalcElapsedTime(meta.StartTime), meta.IsStream, requestPackagePlan)
+		groupQuotaSettled = true
+		return nil
+	}
 	groupRatio := adminmodel.GetGroupChannelBillingRatio(meta.Group, meta.ChannelId)
 	pricing, err := adminmodel.ResolveChannelModelPricing(meta.ChannelProtocol, meta.ChannelModelConfigs, textRequest.Model)
 	if err != nil {
@@ -158,18 +216,17 @@ func RelayTextHelper(c *gin.Context) *model.ErrorWithStatusCode {
 		return openai.ErrorWrapper(err, "calculate_text_quota_failed", http.StatusInternalServerError)
 	}
 	groupReservedQuota := preConsumedSnapshot.ChargeAmount
-	billingPlan, quotaErr := reserveRelayQuota(ctx, meta.Group, meta.UserId, groupReservedQuota)
+	billingPlan, quotaErr := reserveRelayQuota(ctx, meta, groupReservedQuota)
 	if quotaErr != nil {
 		return quotaErr
 	}
-	packageReservation := billingPlan.PackageReservation
 	groupQuotaSettled := false
 	defer func() {
 		if !groupQuotaSettled {
-			releasePackageQuotaReservation(ctx, packageReservation)
+			releaseRelayBillingPlan(ctx, billingPlan)
 		}
 	}()
-	preConsumedQuota, bizErr := preConsumeQuota(ctx, groupReservedQuota, meta, billingPlan.ChargeUserBalance())
+	preConsumedQuota, bizErr := preConsumeQuota(ctx, groupReservedQuota, meta, billingPlan)
 	if bizErr != nil {
 		logger.Warnf(ctx, "preConsumeQuota failed: %+v", *bizErr)
 		return bizErr
@@ -177,7 +234,7 @@ func RelayTextHelper(c *gin.Context) *model.ErrorWithStatusCode {
 	preConsumedQuotaSettled := false
 	defer func() {
 		if !preConsumedQuotaSettled && preConsumedQuota > 0 {
-			billing.ReturnPreConsumedQuota(ctx, preConsumedQuota, meta.TokenId, meta.UserId, billingPlan.ChargeUserBalance())
+			billing.ReturnPreConsumedQuota(ctx, preConsumedQuota, meta.TokenId, meta.UserId, billingPlan.ChargeUserBalance() && billingPlan.ChargeTokenQuota())
 		}
 	}()
 
@@ -217,7 +274,7 @@ func RelayTextHelper(c *gin.Context) *model.ErrorWithStatusCode {
 		return respErr
 	}
 	// post-consume quota
-	go postConsumeQuota(ctx, usage, meta, upstreamRequest, pricing, preConsumedQuota, groupRatio, estimateResult, responsesImageTools, false, billingPlan.ChargeUserBalance(), packageReservation)
+	go postConsumeQuota(ctx, usage, meta, upstreamRequest, pricing, preConsumedQuota, groupRatio, estimateResult, responsesImageTools, false, billingPlan)
 	preConsumedQuotaSettled = true
 	groupQuotaSettled = true
 	return nil

--- a/internal/relay/controller/video.go
+++ b/internal/relay/controller/video.go
@@ -16,6 +16,7 @@ import (
 
 	"github.com/yeying-community/router/common"
 	"github.com/yeying-community/router/common/ctxkey"
+	"github.com/yeying-community/router/common/helper"
 	"github.com/yeying-community/router/common/logger"
 	"github.com/yeying-community/router/internal/admin/model"
 	adminmodel "github.com/yeying-community/router/internal/admin/model"
@@ -344,6 +345,54 @@ func RelayVideoHelper(c *gin.Context, relayMode int) *relaymodel.ErrorWithStatus
 		return relayVideoRawResponse(c, resp, responseBody)
 	}
 
+	if requestPackagePlan, matched, quotaErr := tryBuildRequestPackageBillingPlan(ctx, meta); quotaErr != nil || (matched && requestPackagePlan.UsesRequestPackage()) {
+		if quotaErr != nil {
+			return quotaErr
+		}
+		groupQuotaSettled := false
+		defer func() {
+			if !groupQuotaSettled {
+				releaseRelayBillingPlan(ctx, requestPackagePlan)
+			}
+		}()
+		if err := resetMultipartRequestBody(c); err != nil {
+			return openai.ErrorWrapper(err, "reset_video_request_body_failed", http.StatusInternalServerError)
+		}
+		requestBody, err := common.GetRequestBody(c)
+		if err != nil {
+			return openai.ErrorWrapper(err, "get_video_request_body_failed", http.StatusInternalServerError)
+		}
+		resp, err := adaptor.DoRequest(c, meta, bytes.NewReader(requestBody))
+		if err != nil {
+			return openai.ErrorWrapper(err, "do_request_failed", http.StatusInternalServerError)
+		}
+		defer resp.Body.Close()
+		responseBody, err := io.ReadAll(resp.Body)
+		if err != nil {
+			return openai.ErrorWrapper(err, "read_response_body_failed", http.StatusInternalServerError)
+		}
+		if resp.StatusCode < http.StatusOK || resp.StatusCode >= http.StatusMultipleChoices {
+			resp.Body = io.NopCloser(bytes.NewBuffer(responseBody))
+			return RelayErrorHandler(meta, resp)
+		}
+		responseSummary := extractVideoResponseSummary(responseBody, resp.Header)
+		logger.Infof(
+			ctx,
+			"video request package relay success model=%s channel=%s task_id=%s status=%s result_url=%s request_id=%s",
+			strings.TrimSpace(videoRequest.Model),
+			strings.TrimSpace(meta.ChannelId),
+			responseSummary.TaskID,
+			responseSummary.Status,
+			responseSummary.ResultURL,
+			responseSummary.RequestID,
+		)
+		persistVideoTaskMeta(meta, c.GetString(ctxkey.ChannelName), "", videoRequest.Model, responseSummary, "relay_video_create")
+		go settleRequestPackageOnlyConsumption(ctx, meta, videoRequest.Model, c.GetString(ctxkey.TokenName), 0, 0, helper.CalcElapsedTime(meta.StartTime), false, requestPackagePlan)
+		groupQuotaSettled = true
+		c.Set(ctxkey.UpstreamStatus, resp.StatusCode)
+		return relayVideoRawResponse(c, resp, responseBody)
+	}
+
 	groupRatio := adminmodel.GetGroupChannelBillingRatio(meta.Group, meta.ChannelId)
 	pricing, pricingErr := adminmodel.ResolveChannelModelPricing(meta.ChannelProtocol, meta.ChannelModelConfigs, videoRequest.Model)
 	if pricingErr != nil {
@@ -372,15 +421,14 @@ func RelayVideoHelper(c *gin.Context, relayMode int) *relaymodel.ErrorWithStatus
 		return openai.ErrorWrapper(err, "calculate_video_quota_failed", http.StatusInternalServerError)
 	}
 	quota := billingSnapshot.ChargeAmount
-	billingPlan, quotaErr := reserveRelayQuota(ctx, meta.Group, meta.UserId, quota)
+	billingPlan, quotaErr := reserveRelayQuota(ctx, meta, quota)
 	if quotaErr != nil {
 		return quotaErr
 	}
-	packageReservation := billingPlan.PackageReservation
 	groupQuotaSettled := false
 	defer func() {
 		if !groupQuotaSettled {
-			releasePackageQuotaReservation(ctx, packageReservation)
+			releaseRelayBillingPlan(ctx, billingPlan)
 		}
 	}()
 	if billingPlan.ChargeUserBalance() {
@@ -433,17 +481,17 @@ func RelayVideoHelper(c *gin.Context, relayMode int) *relaymodel.ErrorWithStatus
 
 	defer func(ctx context.Context) {
 		if quota == 0 {
-			settlePackageQuotaReservation(ctx, packageReservation, 0)
+			settleRelayBillingPlan(ctx, billingPlan, 0)
 			return
 		}
 		userDailyQuota := 0
 		userEmergencyQuota := 0
 		if !billingPlan.ChargeUserBalance() {
-			dailyConsumed, emergencyConsumed := settlePackageQuotaReservation(ctx, packageReservation, quota)
+			dailyConsumed, emergencyConsumed := settleRelayBillingPlan(ctx, billingPlan, quota)
 			userDailyQuota = int(dailyConsumed)
 			userEmergencyQuota = int(emergencyConsumed)
 		}
-		if strings.TrimSpace(meta.TokenId) != "" {
+		if strings.TrimSpace(meta.TokenId) != "" && billingPlan.ChargeTokenQuota() {
 			var err error
 			if billingPlan.ChargeUserBalance() {
 				err = model.PostConsumeTokenQuota(meta.TokenId, quota)


### PR DESCRIPTION
## Summary
- add group-scoped request package support in Router
- migrate balance lot transaction amounts for the updated package/balance flow

## Notes
- branch is synced to origin/main
- this PR currently contains 2 commits:
  - `443fad6` feat: add group-scoped request packages
  - `fccdb5f` fix: migrate balance lot transaction amounts