### PR TITLE
feat: refine login flow and package concurrency display

### DIFF
--- a/web/src/components/LoginForm.css
+++ b/web/src/components/LoginForm.css
@@ -84,14 +84,14 @@
 }
 
 .router-login-card {
-  width: min(430px, 100%);
+  width: min(820px, 100%);
   background: #fff;
   border: none;
   border-radius: 14px;
-  padding: 18px;
+  padding: 24px 32px;
   display: flex;
   flex-direction: column;
-  gap: 14px;
+  gap: 18px;
   box-shadow: none;
   margin-top: -20px;
 }
@@ -99,42 +99,125 @@
 .router-login-section {
   display: flex;
   flex-direction: column;
+  gap: 12px;
+  align-items: stretch;
+  width: min(420px, 100%);
+  margin: 0 auto;
+}
+
+.router-wallet-login-row {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) 120px;
   gap: 10px;
+  align-items: stretch;
+  width: 100%;
+}
+
+.router-wallet-address-select {
+  width: 100%;
+}
+
+.router-wallet-address-select .ant-select-selector {
+  min-height: 36px !important;
+  border-radius: 10px !important;
+  border: 2px solid #a9c3f6 !important;
+  padding: 0 10px !important;
+  box-shadow: none !important;
+}
+
+.router-wallet-address-select.ant-select-focused .ant-select-selector,
+.router-wallet-address-select .ant-select-selector:hover {
+  border-color: #8ab1f3 !important;
+}
+
+.router-wallet-address-select .ant-select-selection-wrap {
+  min-height: 32px;
+}
+
+.router-wallet-address-select .ant-select-selection-item,
+.router-wallet-address-select .ant-select-selection-placeholder {
+  align-self: center;
+  font-size: 14px;
+  line-height: 1.2;
+}
+
+.router-wallet-address-select .ant-select-selection-item {
+  color: #5c6575;
+}
+
+.router-wallet-address-select .ant-select-arrow {
+  color: #98a2b3;
+  font-size: 12px;
+  inset-inline-end: 10px;
 }
 
 .router-login-main-btn {
-  width: min(220px, 100%);
-  min-height: 40px;
-  font-size: 1.14285714rem !important;
+  width: 100%;
+  min-height: 36px;
+  font-size: 14px !important;
   border-radius: 10px !important;
-  align-self: center;
-  font-weight: 500 !important;
+  align-self: stretch;
+  font-weight: 600 !important;
   margin: 0 !important;
 }
 
 .router-wallet-button {
-  background: #111827 !important;
+  background: #3f7fdf !important;
   color: #ffffff !important;
+  border: 0 !important;
 }
 
 .router-wallet-button:hover {
-  background: #1f2937 !important;
+  background: #2f73d8 !important;
 }
 
 .router-password-toggle {
   border-radius: 10px !important;
+  min-height: 36px;
+  background: #eef4ff !important;
+  border: 2px solid #b7cdf7 !important;
+  color: #3d6fc4 !important;
+  font-size: 14px !important;
+  font-weight: 600 !important;
+  width: 100% !important;
 }
 
-.router-login-card .ant-divider-horizontal {
-  margin: 2px 0 !important;
-  color: #9aa5b5 !important;
+.router-password-toggle:hover {
+  background: #e6efff !important;
+  color: #2f63be !important;
+  border-color: #a8c2f4 !important;
+}
+
+.router-login-divider-wrap {
+  width: min(420px, 100%);
+  margin: 2px auto;
+}
+
+.router-login-divider.ant-divider,
+.router-login-divider.ant-divider-horizontal,
+.router-login-divider.ant-divider-with-text {
+  width: 100% !important;
+  max-width: 100% !important;
+  margin: 2px auto !important;
+}
+
+.router-login-card .router-login-divider.ant-divider-horizontal {
+  color: #a6afbf !important;
   font-size: 12px !important;
+}
+
+.router-login-card .router-login-divider.ant-divider-horizontal::before,
+.router-login-card .router-login-divider.ant-divider-horizontal::after,
+.router-login-card .router-login-divider.ant-divider-with-text::before,
+.router-login-card .router-login-divider.ant-divider-with-text::after {
+  flex: 1 1 0 !important;
 }
 
 .router-login-form {
   display: flex;
   flex-direction: column;
-  gap: 12px;
+  gap: 8px;
+  width: 100%;
 }
 
 .router-password-submit {
@@ -156,8 +239,9 @@
   justify-content: space-between;
   gap: 12px;
   color: #667085;
-  font-size: 13px;
+  font-size: 12px;
   line-height: 1.5;
+  width: 100%;
 }
 
 .router-login-links a {
@@ -208,6 +292,28 @@
     width: 100%;
     padding: 14px;
     margin-top: -8px;
+  }
+
+  .router-wallet-login-row {
+    grid-template-columns: 1fr;
+  }
+
+  .router-wallet-address-select .ant-select-selector,
+  .router-login-main-btn,
+  .router-password-toggle {
+    min-height: 34px !important;
+    border-radius: 8px !important;
+  }
+
+  .router-wallet-address-select .ant-select-selection-wrap {
+    min-height: 30px;
+  }
+
+  .router-wallet-address-select .ant-select-selection-item,
+  .router-wallet-address-select .ant-select-selection-placeholder,
+  .router-login-main-btn,
+  .router-password-toggle {
+    font-size: 13px !important;
   }
 
   .router-login-links {

--- a/web/src/components/LoginForm.jsx
+++ b/web/src/components/LoginForm.jsx
@@ -11,8 +11,85 @@ import {
   loginWithWallet,
 } from '../services/web3Auth';
 import { useWalletProviderStatus } from '../hooks/useWalletProviderStatus';
-import { AppAlert, AppButton, AppDivider, AppInput } from '../router-ui';
+import {
+  AppAlert,
+  AppButton,
+  AppDivider,
+  AppInput,
+  AppSelect,
+} from '../router-ui';
 import './LoginForm.css';
+
+const WALLET_LOGIN_HISTORY_STORAGE_KEY = 'wallet_login_history';
+const LAST_WALLET_LOGIN_ADDRESS_STORAGE_KEY = 'last_wallet_login_address';
+
+const maskWalletAddress = (value) => {
+  const normalized = String(value || '').trim();
+  if (normalized.length <= 15) {
+    return normalized;
+  }
+  return `${normalized.slice(0, 6)}...${normalized.slice(-6)}`;
+};
+
+const normalizeWalletAddressList = (items) => {
+  if (!Array.isArray(items)) {
+    return [];
+  }
+  const result = [];
+  const seen = new Set();
+  items.forEach((item) => {
+    const normalized = String(item || '').trim();
+    if (normalized === '' || seen.has(normalized.toLowerCase())) {
+      return;
+    }
+    seen.add(normalized.toLowerCase());
+    result.push(normalized);
+  });
+  return result;
+};
+
+const getStoredWalletLoginHistory = () => {
+  if (typeof window === 'undefined') {
+    return [];
+  }
+  try {
+    const raw = window.localStorage.getItem(WALLET_LOGIN_HISTORY_STORAGE_KEY);
+    if (!raw) {
+      return [];
+    }
+    return normalizeWalletAddressList(JSON.parse(raw));
+  } catch (error) {
+    return [];
+  }
+};
+
+const getStoredLastWalletAddress = () => {
+  if (typeof window === 'undefined') {
+    return '';
+  }
+  return String(
+    window.localStorage.getItem(LAST_WALLET_LOGIN_ADDRESS_STORAGE_KEY) || '',
+  ).trim();
+};
+
+const persistWalletLoginHistory = (address) => {
+  const normalizedAddress = String(address || '').trim();
+  if (normalizedAddress === '' || typeof window === 'undefined') {
+    return;
+  }
+  const nextHistory = normalizeWalletAddressList([
+    normalizedAddress,
+    ...getStoredWalletLoginHistory(),
+  ]).slice(0, 8);
+  window.localStorage.setItem(
+    WALLET_LOGIN_HISTORY_STORAGE_KEY,
+    JSON.stringify(nextHistory),
+  );
+  window.localStorage.setItem(
+    LAST_WALLET_LOGIN_ADDRESS_STORAGE_KEY,
+    normalizedAddress,
+  );
+};
 
 const LoginForm = () => {
   const { t } = useTranslation();
@@ -20,6 +97,10 @@ const LoginForm = () => {
     username: '',
     password: '',
   });
+  const [walletAddressOptions, setWalletAddressOptions] = useState([]);
+  const [selectedWalletAddress, setSelectedWalletAddress] = useState(
+    getStoredLastWalletAddress(),
+  );
   const [searchParams] = useSearchParams();
   const { username, password } = inputs;
   const [, userDispatch] = useContext(UserContext);
@@ -56,6 +137,41 @@ const LoginForm = () => {
   const walletProviderStatus = useWalletProviderStatus();
   const resolveLandingPath = (role) =>
     Number(role) >= 10 ? '/admin/dashboard' : '/workspace/entry';
+
+  useEffect(() => {
+    const mergedAddresses = normalizeWalletAddressList([
+      ...walletProviderStatus.accounts,
+      ...getStoredWalletLoginHistory(),
+    ]);
+    setWalletAddressOptions(
+      mergedAddresses.map((address) => ({
+        key: address,
+        value: address,
+        label: maskWalletAddress(address),
+      })),
+    );
+    setSelectedWalletAddress((current) => {
+      const normalizedCurrent = String(current || '').trim();
+      if (
+        normalizedCurrent !== '' &&
+        mergedAddresses.some(
+          (address) => address.toLowerCase() === normalizedCurrent.toLowerCase(),
+        )
+      ) {
+        return normalizedCurrent;
+      }
+      const storedAddress = getStoredLastWalletAddress();
+      if (
+        storedAddress !== '' &&
+        mergedAddresses.some(
+          (address) => address.toLowerCase() === storedAddress.toLowerCase(),
+        )
+      ) {
+        return storedAddress;
+      }
+      return mergedAddresses[0] || '';
+    });
+  }, [walletProviderStatus.accounts]);
 
   useEffect(() => {
     const expiredMarker = searchParams.get('expired');
@@ -99,11 +215,12 @@ const LoginForm = () => {
       }
       await walletProviderStatus.refresh();
       setWalletLoginAwaitingApproval(true);
-      const loginTask = loginWithWallet();
+      const loginTask = loginWithWallet(selectedWalletAddress);
       walletLoginPromiseRef.current = loginTask;
       setWalletLoginSubmitting(false);
       const loginResult = await loginTask;
       setWalletLoginAwaitingApproval(false);
+      persistWalletLoginHistory(loginResult?.address || selectedWalletAddress);
       const payload = loginResult?.response?.data || loginResult?.response;
       if (payload?.expiresAt) {
         localStorage.setItem(
@@ -190,21 +307,38 @@ const LoginForm = () => {
         <div className='router-login-hero'>
           <div className='router-login-card'>
             <div className='router-login-section'>
-              <AppButton
-                fluid
-                className='router-login-main-btn router-auth-button router-wallet-button'
-                onClick={onWalletLoginClicked}
-                disabled={
-                  walletLoginDisabled ||
-                  walletLoginSubmitting ||
-                  (!walletProviderStatus.detecting && !walletProviderStatus.available)
-                }
-                loading={walletLoginSubmitting || walletProviderStatus.detecting}
-              >
-                {walletLoginAwaitingApproval
-                  ? '请在钱包中确认签名'
-                  : t('auth.login.wallet_button', '使用钱包登录')}
-              </AppButton>
+              <div className='router-wallet-login-row'>
+                <AppSelect
+                  className='router-wallet-address-select'
+                  fluid
+                  search
+                  clearable={false}
+                  options={walletAddressOptions}
+                  value={selectedWalletAddress || undefined}
+                  placeholder={t(
+                    'auth.login.wallet_address_placeholder',
+                    '选择钱包地址',
+                  )}
+                  disabled={walletLoginSubmitting}
+                  onChange={(_, { value }) =>
+                    setSelectedWalletAddress(String(value || '').trim())
+                  }
+                />
+                <AppButton
+                  className='router-login-main-btn router-auth-button router-wallet-button'
+                  onClick={onWalletLoginClicked}
+                  disabled={
+                    walletLoginDisabled ||
+                    walletLoginSubmitting ||
+                    selectedWalletAddress === '' ||
+                    (!walletProviderStatus.detecting &&
+                      !walletProviderStatus.available)
+                  }
+                  loading={walletLoginSubmitting || walletProviderStatus.detecting}
+                >
+                  {t('auth.login.wallet_action', '钱包登陆')}
+                </AppButton>
+              </div>
               {walletLoginDisabled && (
                 <AppAlert
                   type='warning'
@@ -231,19 +365,22 @@ const LoginForm = () => {
                 )}
             </div>
 
-            <AppDivider horizontal>或</AppDivider>
+            <div className='router-login-divider-wrap'>
+              <AppDivider className='router-login-divider' horizontal>
+                或
+              </AppDivider>
+            </div>
 
             <div className='router-login-section'>
               {walletLoginEnabled && passwordLoginEnabled && (
                 <AppButton
-                  basic
                   fluid
                   className='router-login-main-btn router-auth-button router-password-toggle'
                   onClick={() =>
                     setShowPasswordLogin((previousState) => !previousState)
                   }
                 >
-                  {t('auth.login.password_button', '使用账密登录')}
+                  {t('auth.login.password_action', '密码登陆')}
                 </AppButton>
               )}
 

--- a/web/src/helpers/package.js
+++ b/web/src/helpers/package.js
@@ -124,6 +124,22 @@ export const formatPackageConcurrencyLimit = (item, t, emptyLabel = '-') => {
   return parts.join(' / ');
 };
 
+export const formatUserFacingPackageConcurrency = (
+  item,
+  t,
+  emptyLabel = '-',
+) => {
+  const perPackage = Number(item?.max_concurrency_per_package || 0);
+  if (Number.isFinite(perPackage) && perPackage > 0) {
+    return `${perPackage}`;
+  }
+  const perUser = Number(item?.max_concurrency_per_user || 0);
+  if (Number.isFinite(perUser) && perUser > 0) {
+    return `${perUser}`;
+  }
+  return emptyLabel === t?.('common.unlimited') ? emptyLabel : emptyLabel;
+};
+
 export const formatPackageExtraEntitlement = (item, t, emergencyValue = '') => {
   if (isRequestQuotaPackage(item)) {
     return formatRequestQuotaConcurrency(item, t);

--- a/web/src/index.css
+++ b/web/src/index.css
@@ -2,7 +2,8 @@ body {
     margin: 0;
     padding-top: 0;
     overflow-y: scroll;
-    font-family: 'Helvetica Neue', Arial, Helvetica, "Microsoft YaHei", sans-serif;
+    font-family: "Noto Sans", "SF Pro SC", "SF Pro Text", "SF Pro Icons",
+      "PingFang SC", "Helvetica Neue", "Helvetica", "Arial", sans-serif;
     -webkit-font-smoothing: antialiased;
     -moz-osx-font-smoothing: grayscale;
     scrollbar-width: none;
@@ -10,7 +11,8 @@ body {
 
 :root {
     --router-shell-horizontal-padding: 24px;
-    --router-font-family: 'Helvetica Neue', Arial, Helvetica, "Microsoft YaHei", sans-serif;
+    --router-font-family: "Noto Sans", "SF Pro SC", "SF Pro Text", "SF Pro Icons",
+      "PingFang SC", "Helvetica Neue", "Helvetica", "Arial", sans-serif;
     --router-font-weight-normal: 400;
     --router-font-weight-medium: 500;
 }

--- a/web/src/locales/en/translation.json
+++ b/web/src/locales/en/translation.json
@@ -3375,7 +3375,11 @@
       "other_methods": "Other login methods",
       "wallet_title": "Wallet Login",
       "wallet_button": "Sign in with wallet",
+      "wallet_action": "Wallet Login",
+      "wallet_pending": "Confirm the signature in your wallet",
+      "wallet_address_placeholder": "Select wallet address",
       "password_button": "Sign in with password",
+      "password_action": "Password Login",
       "password_disabled": "Password login is disabled",
       "wallet_disabled": "Wallet login is disabled",
       "wechat": {

--- a/web/src/locales/zh/translation.json
+++ b/web/src/locales/zh/translation.json
@@ -3370,7 +3370,11 @@
       "other_methods": "使用其他方式登录",
       "wallet_title": "钱包登录",
       "wallet_button": "使用钱包登录",
+      "wallet_action": "钱包登陆",
+      "wallet_pending": "请在钱包中确认签名",
+      "wallet_address_placeholder": "选择钱包地址",
       "password_button": "使用账密登录",
+      "password_action": "密码登陆",
       "password_disabled": "用户名密码登录未开启",
       "wallet_disabled": "钱包登录未开启",
       "wechat": {

--- a/web/src/pages/TopUp/CurrentPackagePage.jsx
+++ b/web/src/pages/TopUp/CurrentPackagePage.jsx
@@ -16,7 +16,7 @@ import {
   useTopUpWorkspace,
 } from './shared.jsx';
 import {
-  formatPackageConcurrencyLimit,
+  formatUserFacingPackageConcurrency,
   formatRequestCount,
   getServicePackagePeriodLabel,
   getServicePackageTypeLabel,
@@ -373,7 +373,11 @@ const CurrentPackagePage = () => {
         {
           key: 'concurrency',
           label: t('package_manage.table.concurrency_limit'),
-          value: formatPackageConcurrencyLimit(activeSubscription, t, t('common.unlimited')),
+          value: formatUserFacingPackageConcurrency(
+            activeSubscription,
+            t,
+            t('common.unlimited'),
+          ),
         },
       ]
       : [
@@ -392,7 +396,11 @@ const CurrentPackagePage = () => {
         {
           key: 'concurrency',
           label: t('package_manage.table.concurrency_limit'),
-          value: formatPackageConcurrencyLimit(activeSubscription, t, t('common.unlimited')),
+          value: formatUserFacingPackageConcurrency(
+            activeSubscription,
+            t,
+            t('common.unlimited'),
+          ),
         },
       ];
     return [
@@ -436,7 +444,11 @@ const CurrentPackagePage = () => {
         {
           key: 'concurrency',
           label: t('package_manage.table.concurrency_limit'),
-          value: formatPackageConcurrencyLimit(nextSubscription, t, t('common.unlimited')),
+          value: formatUserFacingPackageConcurrency(
+            nextSubscription,
+            t,
+            t('common.unlimited'),
+          ),
         },
       ]
       : [
@@ -453,7 +465,11 @@ const CurrentPackagePage = () => {
         {
           key: 'concurrency',
           label: t('package_manage.table.concurrency_limit'),
-          value: formatPackageConcurrencyLimit(nextSubscription, t, t('common.unlimited')),
+          value: formatUserFacingPackageConcurrency(
+            nextSubscription,
+            t,
+            t('common.unlimited'),
+          ),
         },
       ];
     return [

--- a/web/src/pages/TopUp/PackagePurchasePage.jsx
+++ b/web/src/pages/TopUp/PackagePurchasePage.jsx
@@ -4,8 +4,8 @@ import { API, showError, showInfo, timestamp2string } from '../../helpers';
 import { buildTopUpReturnURL, useTopUpWorkspace } from './shared.jsx';
 import { AppButton, AppModal, AppSection, AppTag } from '../../router-ui';
 import {
-  formatPackageConcurrencyLimit,
   formatRequestQuotaEntitlement,
+  formatUserFacingPackageConcurrency,
   getServicePackageTypeLabel,
   isRequestQuotaPackage,
   normalizeServicePackageType,
@@ -316,7 +316,11 @@ const PackagePurchasePage = () => {
                               {t('package_manage.table.concurrency_limit')}
                             </div>
                             <div className='router-package-purchase-meta-value'>
-                              {formatPackageConcurrencyLimit(item, t)}
+                              {formatUserFacingPackageConcurrency(
+                                item,
+                                t,
+                                t('common.unlimited'),
+                              )}
                             </div>
                           </div>
                         </div>

--- a/web/src/services/web3Auth.jsx
+++ b/web/src/services/web3Auth.jsx
@@ -67,10 +67,17 @@ export async function requireWalletProvider() {
   return provider;
 }
 
-export async function getWalletContext() {
+export async function getWalletContext(preferredAddress = '') {
   const provider = await requireWalletProvider();
   const accounts = await requestAccounts({ provider });
-  const address = accounts?.[0];
+  const normalizedPreferredAddress = String(preferredAddress || '').trim().toLowerCase();
+  const matchedAddress = Array.isArray(accounts)
+    ? accounts.find(
+        (item) =>
+          String(item || '').trim().toLowerCase() === normalizedPreferredAddress,
+      )
+    : '';
+  const address = matchedAddress || accounts?.[0];
   if (!address) {
     throw new Error('未获取到钱包账户');
   }
@@ -78,8 +85,8 @@ export async function getWalletContext() {
   return { provider, address, chainId };
 }
 
-async function loginWithWalletOnce() {
-  const { provider, address } = await getWalletContext();
+async function loginWithWalletOnce(preferredAddress = '') {
+  const { provider, address } = await getWalletContext(preferredAddress);
   const loginResult = await loginWithChallenge({
     provider,
     address,
@@ -88,15 +95,15 @@ async function loginWithWalletOnce() {
   return { ...loginResult, provider, address };
 }
 
-export async function loginWithWallet() {
+export async function loginWithWallet(preferredAddress = '') {
   try {
-    return await loginWithWalletOnce();
+    return await loginWithWalletOnce(preferredAddress);
   } catch (error) {
     if (!isWalletReconnectError(error) || isUserRejectedWalletAction(error)) {
       throw error;
     }
     await waitForWalletProviderReconnect();
-    return await loginWithWalletOnce();
+    return await loginWithWalletOnce(preferredAddress);
   }
 }
 


### PR DESCRIPTION
## Summary
- remember wallet login addresses and allow choosing the previously used address on the login page
- tighten the login control layout, align the divider with the control width, and keep wallet button text stable while loading
- show a simplified user-facing concurrency value in workspace package cards and purchase views

## Testing
- cd web && npm run build