### PR TITLE
fix: allow first-time wallet login without history

### DIFF
--- a/web/src/components/LoginForm.jsx
+++ b/web/src/components/LoginForm.jsx
@@ -330,7 +330,6 @@ const LoginForm = () => {
                   disabled={
                     walletLoginDisabled ||
                     walletLoginSubmitting ||
-                    selectedWalletAddress === '' ||
                     (!walletProviderStatus.detecting &&
                       !walletProviderStatus.available)
                   }


### PR DESCRIPTION
## Summary
- allow wallet login to proceed even when no wallet address history exists yet
- keep the existing wallet availability checks and let the wallet flow resolve the first account

## Testing
- cd web && npm run build