### PR TITLE
fix responses passthrough model rewrite

### DIFF
--- a/internal/relay/controller/text.go
+++ b/internal/relay/controller/text.go
@@ -257,7 +257,11 @@ func prepareTextBillingRequestBody(c *gin.Context, meta *meta.Meta, rawRequestBo
 		}
 		return applyEndpointRequestPolicy(c, meta, normalizedBody)
 	case meta.Mode == relaymode.Responses && upstreamMode == relaymode.Responses:
-		return applyEndpointRequestPolicy(c, meta, rawBody)
+		normalizedBody, err := normalizeTextModelRequestBody(rawBody, meta.ActualModelName)
+		if err != nil {
+			return nil, err
+		}
+		return applyEndpointRequestPolicy(c, meta, normalizedBody)
 	case !config.EnforceIncludeUsage &&
 		meta.APIType == apitype.OpenAI &&
 		meta.OriginModelName == meta.ActualModelName &&
@@ -326,6 +330,10 @@ func getRequestBody(c *gin.Context, meta *meta.Meta, textRequest *model.GeneralO
 	}
 	if meta.Mode == relaymode.Responses && upstreamMode == relaymode.Responses {
 		rawBody, err := common.GetRequestBody(c)
+		if err != nil {
+			return nil, err
+		}
+		rawBody, err = normalizeTextModelRequestBody(rawBody, meta.ActualModelName)
 		if err != nil {
 			return nil, err
 		}

--- a/internal/relay/controller/text_routing.go
+++ b/internal/relay/controller/text_routing.go
@@ -27,6 +27,20 @@ func normalizeMessagesRequestBody(raw []byte, modelName string) ([]byte, error) 
 	return json.Marshal(payload)
 }
 
+func normalizeTextModelRequestBody(raw []byte, modelName string) ([]byte, error) {
+	if len(raw) == 0 {
+		return raw, nil
+	}
+	payload := map[string]any{}
+	if err := json.Unmarshal(raw, &payload); err != nil {
+		return nil, err
+	}
+	if strings.TrimSpace(modelName) != "" {
+		payload["model"] = strings.TrimSpace(modelName)
+	}
+	return json.Marshal(payload)
+}
+
 func cloneGeneralOpenAIRequest(req *relaymodel.GeneralOpenAIRequest) (*relaymodel.GeneralOpenAIRequest, error) {
 	if req == nil {
 		return nil, fmt.Errorf("request is nil")


### PR DESCRIPTION
## Summary
- rewrite `/v1/responses` passthrough request `model` to the routed actual model
- keep endpoint request policy application after model normalization
- do not include prior empty-response / SSE usage temporary changes

## Tests
- `go test ./internal/relay/controller ./internal/relay/adaptor/openai ./internal/admin/controller -run 'Test.*(Routing|Responses|StreamResponsesHandler|ShouldRetry)'`