### PR TITLE
fix provider cache pricing persistence

### DIFF
--- a/internal/admin/model/migration_runner.go
+++ b/internal/admin/model/migration_runner.go
@@ -1733,6 +1733,13 @@ func runMainVersionedMigrations(db *gorm.DB) error {
 				return upsertProviderMigrationProvidersWithDB(tx, "openai", "deepseek", "xai")
 			},
 		},
+		{
+			Version:     "202607101030_repair_provider_text_cache_pricing_components",
+			Description: "restore provider text cache pricing components removed by provider catalog refreshes",
+			Up: func(tx *gorm.DB) error {
+				return upsertProviderTextCachePricingComponentsWithDB(tx)
+			},
+		},
 	}
 	return runVersionedMigrations(db, migrationScopeMain, migrations)
 }

--- a/internal/admin/model/provider_migration_data_test.go
+++ b/internal/admin/model/provider_migration_data_test.go
@@ -357,6 +357,85 @@ func TestUpsertProviderTextCachePricingComponentsWithDB(t *testing.T) {
 	}
 }
 
+func TestUpsertProviderMigrationProvidersPreservesTextCachePricingComponents(t *testing.T) {
+	db := newProviderMigrationTestDB(t)
+	if err := upsertProviderMigrationProvidersWithDB(db, "openai"); err != nil {
+		t.Fatalf("seed openai provider catalog: %v", err)
+	}
+
+	cacheRead := ProviderModelPriceComponent{}
+	if err := db.First(
+		&cacheRead,
+		"provider = ? AND model = ? AND component = ? AND condition = ?",
+		"openai",
+		"gpt-5.5",
+		ProviderModelPriceComponentTextCacheRead,
+		"",
+	).Error; err != nil {
+		t.Fatalf("query initial openai cache read component: %v", err)
+	}
+	if cacheRead.InputPrice != 0.0005 || cacheRead.Source != "migration" {
+		t.Fatalf("initial openai cache read price=%v source=%q, want 0.0005 migration", cacheRead.InputPrice, cacheRead.Source)
+	}
+
+	if err := db.Model(&ProviderModelPriceComponent{}).
+		Where(
+			"provider = ? AND model = ? AND component = ? AND condition = ?",
+			"openai",
+			"gpt-5.5",
+			ProviderModelPriceComponentTextCacheRead,
+			"",
+		).
+		Update("input_price", 0.123).Error; err != nil {
+		t.Fatalf("make migration cache price stale: %v", err)
+	}
+	if err := db.Create(&ProviderModelPriceComponent{
+		Provider:   "openai",
+		Model:      "gpt-5.5",
+		Component:  "manual_test_component",
+		InputPrice: 0.321,
+		PriceUnit:  ProviderPriceUnitPer1KTokens,
+		Currency:   ProviderPriceCurrencyUSD,
+		Source:     "manual",
+	}).Error; err != nil {
+		t.Fatalf("create manual provider component: %v", err)
+	}
+
+	if err := upsertProviderMigrationProvidersWithDB(db, "openai"); err != nil {
+		t.Fatalf("refresh openai provider catalog: %v", err)
+	}
+
+	if err := db.First(
+		&cacheRead,
+		"provider = ? AND model = ? AND component = ? AND condition = ?",
+		"openai",
+		"gpt-5.5",
+		ProviderModelPriceComponentTextCacheRead,
+		"",
+	).Error; err != nil {
+		t.Fatalf("query refreshed openai cache read component: %v", err)
+	}
+	if cacheRead.InputPrice != 0.0005 || cacheRead.Source != "migration" {
+		t.Fatalf("refreshed openai cache read price=%v source=%q, want 0.0005 migration", cacheRead.InputPrice, cacheRead.Source)
+	}
+
+	manualCount := int64(0)
+	if err := db.Model(&ProviderModelPriceComponent{}).
+		Where(
+			"provider = ? AND model = ? AND component = ? AND source = ?",
+			"openai",
+			"gpt-5.5",
+			"manual_test_component",
+			"manual",
+		).
+		Count(&manualCount).Error; err != nil {
+		t.Fatalf("count manual provider component: %v", err)
+	}
+	if manualCount != 1 {
+		t.Fatalf("manual provider component count=%d, want 1", manualCount)
+	}
+}
+
 func TestLoadProviderMigrationSeedsFromSnapshot(t *testing.T) {
 	seeds := mustLoadProviderMigrationSeeds(t)
 	if len(seeds) == 0 {

--- a/internal/admin/model/provider_seed.go
+++ b/internal/admin/model/provider_seed.go
@@ -202,7 +202,16 @@ func upsertProviderMigrationSeedsWithDB(db *gorm.DB, providers []string) error {
 			if len(targetModels) == 0 {
 				continue
 			}
-			if err := tx.Where("provider = ? AND model IN ?", provider, targetModels).
+			if err := tx.Where(
+				"provider = ? AND model IN ? AND source = ? AND component NOT IN ?",
+				provider,
+				targetModels,
+				"migration",
+				[]string{
+					ProviderModelPriceComponentTextCacheRead,
+					ProviderModelPriceComponentTextCacheWrite,
+				},
+			).
 				Delete(&ProviderModelPriceComponent{}).Error; err != nil {
 				return err
 			}
@@ -250,7 +259,7 @@ func upsertProviderMigrationSeedsWithDB(db *gorm.DB, providers []string) error {
 				return err
 			}
 		}
-		return nil
+		return upsertProviderTextCachePricingComponentsInTransaction(tx)
 	})
 }
 

--- a/internal/admin/model/provider_text_cache_pricing_migration.go
+++ b/internal/admin/model/provider_text_cache_pricing_migration.go
@@ -8,7 +8,6 @@ import (
 
 	"github.com/yeying-community/router/common/helper"
 	"gorm.io/gorm"
-	"gorm.io/gorm/clause"
 )
 
 const (
@@ -100,13 +99,17 @@ func upsertProviderTextCachePricingComponentsWithDB(db *gorm.DB) error {
 		return err
 	}
 	return db.Transaction(func(tx *gorm.DB) error {
-		for _, rule := range providerTextCachePricingRules {
-			if err := upsertProviderTextCachePricingRuleWithDB(tx, rule); err != nil {
-				return err
-			}
-		}
-		return nil
+		return upsertProviderTextCachePricingComponentsInTransaction(tx)
 	})
+}
+
+func upsertProviderTextCachePricingComponentsInTransaction(db *gorm.DB) error {
+	for _, rule := range providerTextCachePricingRules {
+		if err := upsertProviderTextCachePricingRuleWithDB(db, rule); err != nil {
+			return err
+		}
+	}
+	return nil
 }
 
 func upsertProviderTextCachePricingRuleWithDB(db *gorm.DB, rule providerTextCachePricingRule) error {
@@ -140,15 +143,50 @@ func upsertProviderTextCachePricingRuleWithDB(db *gorm.DB, rule providerTextCach
 	if len(rows) == 0 {
 		return nil
 	}
-	return db.Clauses(clause.OnConflict{
-		Columns: []clause.Column{
-			{Name: "provider"},
-			{Name: "model"},
-			{Name: "component"},
-			{Name: "condition"},
-		},
-		DoNothing: true,
-	}).Create(&rows).Error
+	for _, row := range rows {
+		if err := upsertProviderTextCachePricingComponentWithDB(db, row); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func upsertProviderTextCachePricingComponentWithDB(db *gorm.DB, row ProviderModelPriceComponent) error {
+	existing := ProviderModelPriceComponent{}
+	result := db.Where(
+		"provider = ? AND model = ? AND component = ? AND condition = ?",
+		row.Provider,
+		row.Model,
+		row.Component,
+		row.Condition,
+	).Limit(1).Find(&existing)
+	if result.Error != nil {
+		return result.Error
+	}
+	if result.RowsAffected == 0 {
+		return db.Create(&row).Error
+	}
+	if strings.TrimSpace(strings.ToLower(existing.Source)) != "migration" {
+		return nil
+	}
+	return db.Model(&ProviderModelPriceComponent{}).
+		Where(
+			"provider = ? AND model = ? AND component = ? AND condition = ?",
+			row.Provider,
+			row.Model,
+			row.Component,
+			row.Condition,
+		).
+		Updates(map[string]any{
+			"input_price":  row.InputPrice,
+			"output_price": row.OutputPrice,
+			"price_unit":   row.PriceUnit,
+			"currency":     row.Currency,
+			"source":       row.Source,
+			"source_url":   row.SourceURL,
+			"sort_order":   row.SortOrder,
+			"updated_at":   row.UpdatedAt,
+		}).Error
 }
 
 func buildProviderTextCachePricingComponent(providerModel ProviderModel, component string, rate float64, sourceURL string, now int64, sortOrder int) ProviderModelPriceComponent {


### PR DESCRIPTION
## Summary
- preserve manual and text cache pricing components during provider catalog refreshes
- automatically restore and update official cache pricing after provider refreshes
- add a repair migration for components removed by the later OpenAI provider refresh
- add regression coverage for OpenAI gpt-5.5 cache pricing persistence

## Production verification
- repair migration applied successfully
- openai/gpt-5.5 cache read price restored to 0.0005 USD per 1K tokens

## Tests
- focused provider migration tests
- relay billing and controller cache/pricing tests