### PR TITLE
Add GPT-5.6 OpenAI provider migration

### DIFF
--- a/internal/admin/model/migration_runner.go
+++ b/internal/admin/model/migration_runner.go
@@ -1740,6 +1740,13 @@ func runMainVersionedMigrations(db *gorm.DB) error {
 				return upsertProviderTextCachePricingComponentsWithDB(tx)
 			},
 		},
+		{
+			Version:     "202607101130_refresh_openai_provider_for_gpt56_models",
+			Description: "refresh openai provider migration rows to add GPT-5.6 family models",
+			Up: func(tx *gorm.DB) error {
+				return upsertProviderMigrationProvidersWithDB(tx, "openai")
+			},
+		},
 	}
 	return runVersionedMigrations(db, migrationScopeMain, migrations)
 }

--- a/internal/admin/model/provider_migration_data_test.go
+++ b/internal/admin/model/provider_migration_data_test.go
@@ -263,6 +263,18 @@ func TestUpsertProviderTextCachePricingComponentsWithDB(t *testing.T) {
 	}).Error; err != nil {
 		t.Fatalf("create qwen provider model: %v", err)
 	}
+	if err := db.Create(&ProviderModel{
+		Provider:    "openai",
+		Model:       "gpt-5.6-sol",
+		Tags:        ProviderModelTypeText,
+		InputPrice:  0.015,
+		OutputPrice: 0.12,
+		PriceUnit:   ProviderPriceUnitPer1KTokens,
+		Currency:    ProviderPriceCurrencyUSD,
+		Source:      "migration",
+	}).Error; err != nil {
+		t.Fatalf("create openai gpt-5.6-sol provider model: %v", err)
+	}
 	if err := db.Create(&ProviderModelPriceComponent{
 		Provider:   "openai",
 		Model:      "gpt-5.4",
@@ -292,6 +304,34 @@ func TestUpsertProviderTextCachePricingComponentsWithDB(t *testing.T) {
 	}
 	if openAIRead.InputPrice != 0.123 || openAIRead.Source != "manual" {
 		t.Fatalf("manual openai cache read component overwritten: price=%v source=%q", openAIRead.InputPrice, openAIRead.Source)
+	}
+	openAISolRead := ProviderModelPriceComponent{}
+	if err := db.First(
+		&openAISolRead,
+		"provider = ? AND model = ? AND component = ? AND condition = ?",
+		"openai",
+		"gpt-5.6-sol",
+		ProviderModelPriceComponentTextCacheRead,
+		"",
+	).Error; err != nil {
+		t.Fatalf("query openai gpt-5.6-sol cache read component: %v", err)
+	}
+	if openAISolRead.InputPrice != 0.0015 {
+		t.Fatalf("openai gpt-5.6-sol cache read input_price=%v, want 0.0015", openAISolRead.InputPrice)
+	}
+	openAISolWrite := ProviderModelPriceComponent{}
+	if err := db.First(
+		&openAISolWrite,
+		"provider = ? AND model = ? AND component = ? AND condition = ?",
+		"openai",
+		"gpt-5.6-sol",
+		ProviderModelPriceComponentTextCacheWrite,
+		"",
+	).Error; err != nil {
+		t.Fatalf("query openai gpt-5.6-sol cache write component: %v", err)
+	}
+	if openAISolWrite.InputPrice != 0.01875 {
+		t.Fatalf("openai gpt-5.6-sol cache write input_price=%v, want 0.01875", openAISolWrite.InputPrice)
 	}
 
 	anthropicRead := ProviderModelPriceComponent{}
@@ -954,6 +994,10 @@ func TestBuildProviderMigrationSeeds_OpenAIIncludesGPT5xPricing(t *testing.T) {
 		"gpt-5.1-codex":      {input: 0.00125, output: 0.01},
 		"gpt-5.1-codex-max":  {input: 0.00125, output: 0.01},
 		"gpt-5.1-codex-mini": {input: 0.00025, output: 0.002},
+		"gpt-5.6":            {input: 0.015, output: 0.12},
+		"gpt-5.6-sol":        {input: 0.015, output: 0.12},
+		"gpt-5.6-terra":      {input: 0.003, output: 0.024},
+		"gpt-5.6-luna":       {input: 0.0006, output: 0.0048},
 	}
 
 	for _, seed := range seeds {
@@ -1033,6 +1077,9 @@ func TestBuildProviderMigrationSeeds_OpenAIIncludesNewOfficialModels(t *testing.
 		"gpt-5.4-nano":           {modelType: ProviderModelTypeText},
 		"gpt-5.4-pro":            {modelType: ProviderModelTypeText},
 		"gpt-5.5-pro":            {modelType: ProviderModelTypeText},
+		"gpt-5.6-sol":            {modelType: ProviderModelTypeText},
+		"gpt-5.6-terra":          {modelType: ProviderModelTypeText},
+		"gpt-5.6-luna":           {modelType: ProviderModelTypeText},
 		"gpt-image-1.5":          {modelType: ProviderModelTypeImage},
 		"gpt-image-1-mini":       {modelType: ProviderModelTypeImage},
 		"gpt-realtime-translate": {modelType: ProviderModelTypeAudio},
@@ -1064,6 +1111,38 @@ func TestBuildProviderMigrationSeeds_OpenAIIncludesNewOfficialModels(t *testing.
 			}
 		}
 		return
+	}
+	t.Fatalf("expected openai provider to exist")
+}
+
+func TestBuildProviderMigrationSeeds_OpenAIIncludesGPT56AliasPricing(t *testing.T) {
+	seeds := mustLoadProviderMigrationSeeds(t)
+	for _, seed := range seeds {
+		if seed.Provider != "openai" {
+			continue
+		}
+		for _, detail := range seed.ModelDetails {
+			if detail.Model != "gpt-5.6" {
+				continue
+			}
+			if detail.Type != ProviderModelTypeText {
+				t.Fatalf("gpt-5.6 type=%q, want %q", detail.Type, ProviderModelTypeText)
+			}
+			if detail.InputPrice != 0.015 {
+				t.Fatalf("gpt-5.6 input_price=%v, want 0.015", detail.InputPrice)
+			}
+			if detail.OutputPrice != 0.12 {
+				t.Fatalf("gpt-5.6 output_price=%v, want 0.12", detail.OutputPrice)
+			}
+			if detail.PriceUnit != ProviderPriceUnitPer1KTokens {
+				t.Fatalf("gpt-5.6 price_unit=%q, want %q", detail.PriceUnit, ProviderPriceUnitPer1KTokens)
+			}
+			if detail.Currency != ProviderPriceCurrencyUSD {
+				t.Fatalf("gpt-5.6 currency=%q, want %q", detail.Currency, ProviderPriceCurrencyUSD)
+			}
+			return
+		}
+		t.Fatalf("expected openai seed to include gpt-5.6")
 	}
 	t.Fatalf("expected openai provider to exist")
 }

--- a/internal/admin/model/provider_migration_snapshot.json
+++ b/internal/admin/model/provider_migration_snapshot.json
@@ -1608,6 +1608,294 @@
         }
       },
       {
+        "model": "gpt-5.6",
+        "type": "text",
+        "status": "active",
+        "description": "GPT-5.6 是 OpenAI 当前默认指向的旗舰模型别名，现阶段路由到 GPT-5.6 Sol。",
+        "supported_endpoints": [
+          "/v1/chat/completions",
+          "/v1/responses"
+        ],
+        "input_price": 0.015,
+        "output_price": 0.12,
+        "price_unit": "per_1k_tokens",
+        "currency": "USD",
+        "source": "migration",
+        "updated_at": 1700000000,
+        "tags": [
+          "vision"
+        ],
+        "specification": {
+          "version": 1,
+          "endpoints": {
+            "/v1/chat/completions": {
+              "input_modalities": [
+                "image",
+                "text"
+              ],
+              "output_modalities": [
+                "text"
+              ],
+              "parameters": {
+                "detail": {
+                  "type": "enum",
+                  "allowed_values": [
+                    "auto",
+                    "high",
+                    "low",
+                    "original"
+                  ]
+                }
+              },
+              "constraints": {
+                "max_images": 1500,
+                "max_payload_size_mb": 512
+              }
+            },
+            "/v1/responses": {
+              "input_modalities": [
+                "image",
+                "text"
+              ],
+              "output_modalities": [
+                "text"
+              ],
+              "parameters": {
+                "detail": {
+                  "type": "enum",
+                  "allowed_values": [
+                    "auto",
+                    "high",
+                    "low",
+                    "original"
+                  ]
+                }
+              },
+              "constraints": {
+                "max_images": 1500,
+                "max_payload_size_mb": 512
+              }
+            }
+          }
+        }
+      },
+      {
+        "model": "gpt-5.6-sol",
+        "type": "text",
+        "status": "active",
+        "description": "GPT-5.6 Sol 是 GPT-5.6 系列中的旗舰高能力模型，适合复杂推理和生产任务。",
+        "supported_endpoints": [
+          "/v1/chat/completions",
+          "/v1/responses"
+        ],
+        "input_price": 0.015,
+        "output_price": 0.12,
+        "price_unit": "per_1k_tokens",
+        "currency": "USD",
+        "source": "migration",
+        "updated_at": 1700000000,
+        "tags": [
+          "vision"
+        ],
+        "specification": {
+          "version": 1,
+          "endpoints": {
+            "/v1/chat/completions": {
+              "input_modalities": [
+                "image",
+                "text"
+              ],
+              "output_modalities": [
+                "text"
+              ],
+              "parameters": {
+                "detail": {
+                  "type": "enum",
+                  "allowed_values": [
+                    "auto",
+                    "high",
+                    "low",
+                    "original"
+                  ]
+                }
+              },
+              "constraints": {
+                "max_images": 1500,
+                "max_payload_size_mb": 512
+              }
+            },
+            "/v1/responses": {
+              "input_modalities": [
+                "image",
+                "text"
+              ],
+              "output_modalities": [
+                "text"
+              ],
+              "parameters": {
+                "detail": {
+                  "type": "enum",
+                  "allowed_values": [
+                    "auto",
+                    "high",
+                    "low",
+                    "original"
+                  ]
+                }
+              },
+              "constraints": {
+                "max_images": 1500,
+                "max_payload_size_mb": 512
+              }
+            }
+          }
+        }
+      },
+      {
+        "model": "gpt-5.6-terra",
+        "type": "text",
+        "status": "active",
+        "description": "GPT-5.6 Terra 是 GPT-5.6 系列中的中高能力版本，兼顾成本与效果。",
+        "supported_endpoints": [
+          "/v1/chat/completions",
+          "/v1/responses"
+        ],
+        "input_price": 0.003,
+        "output_price": 0.024,
+        "price_unit": "per_1k_tokens",
+        "currency": "USD",
+        "source": "migration",
+        "updated_at": 1700000000,
+        "tags": [
+          "vision"
+        ],
+        "specification": {
+          "version": 1,
+          "endpoints": {
+            "/v1/chat/completions": {
+              "input_modalities": [
+                "image",
+                "text"
+              ],
+              "output_modalities": [
+                "text"
+              ],
+              "parameters": {
+                "detail": {
+                  "type": "enum",
+                  "allowed_values": [
+                    "auto",
+                    "high",
+                    "low",
+                    "original"
+                  ]
+                }
+              },
+              "constraints": {
+                "max_images": 1500,
+                "max_payload_size_mb": 512
+              }
+            },
+            "/v1/responses": {
+              "input_modalities": [
+                "image",
+                "text"
+              ],
+              "output_modalities": [
+                "text"
+              ],
+              "parameters": {
+                "detail": {
+                  "type": "enum",
+                  "allowed_values": [
+                    "auto",
+                    "high",
+                    "low",
+                    "original"
+                  ]
+                }
+              },
+              "constraints": {
+                "max_images": 1500,
+                "max_payload_size_mb": 512
+              }
+            }
+          }
+        }
+      },
+      {
+        "model": "gpt-5.6-luna",
+        "type": "text",
+        "status": "active",
+        "description": "GPT-5.6 Luna 是 GPT-5.6 系列中的低成本轻量版本，适合高并发常规任务。",
+        "supported_endpoints": [
+          "/v1/chat/completions",
+          "/v1/responses"
+        ],
+        "input_price": 0.0006,
+        "output_price": 0.0048,
+        "price_unit": "per_1k_tokens",
+        "currency": "USD",
+        "source": "migration",
+        "updated_at": 1700000000,
+        "tags": [
+          "vision"
+        ],
+        "specification": {
+          "version": 1,
+          "endpoints": {
+            "/v1/chat/completions": {
+              "input_modalities": [
+                "image",
+                "text"
+              ],
+              "output_modalities": [
+                "text"
+              ],
+              "parameters": {
+                "detail": {
+                  "type": "enum",
+                  "allowed_values": [
+                    "auto",
+                    "high",
+                    "low",
+                    "original"
+                  ]
+                }
+              },
+              "constraints": {
+                "max_images": 1500,
+                "max_payload_size_mb": 512
+              }
+            },
+            "/v1/responses": {
+              "input_modalities": [
+                "image",
+                "text"
+              ],
+              "output_modalities": [
+                "text"
+              ],
+              "parameters": {
+                "detail": {
+                  "type": "enum",
+                  "allowed_values": [
+                    "auto",
+                    "high",
+                    "low",
+                    "original"
+                  ]
+                }
+              },
+              "constraints": {
+                "max_images": 1500,
+                "max_payload_size_mb": 512
+              }
+            }
+          }
+        }
+      },
+      {
         "model": "gpt-audio",
         "type": "audio",
         "status": "active",

--- a/internal/admin/model/provider_text_cache_pricing_migration.go
+++ b/internal/admin/model/provider_text_cache_pricing_migration.go
@@ -33,11 +33,16 @@ type providerTextCachePricingRule struct {
 var providerTextCachePricingRules = []providerTextCachePricingRule{
 	// OpenAI pricing exposes cached input as 10% of regular text input for the
 	// current OpenAI text models where the catalog's base price matches the
-	// standard official price row.
+	// standard official price row. GPT-5.6 family models additionally publish
+	// explicit cache write pricing at 125% of the uncached input rate.
 	{Provider: "openai", Model: "gpt-5.3-codex", CacheReadRate: 0.1, SourceURL: providerTextCachePricingOpenAIURL},
 	{Provider: "openai", Model: "gpt-5.4", CacheReadRate: 0.1, SourceURL: providerTextCachePricingOpenAIURL},
 	{Provider: "openai", Model: "gpt-5.4-mini", CacheReadRate: 0.1, SourceURL: providerTextCachePricingOpenAIURL},
 	{Provider: "openai", Model: "gpt-5.5", CacheReadRate: 0.1, SourceURL: providerTextCachePricingOpenAIURL},
+	{Provider: "openai", Model: "gpt-5.6", CacheReadRate: 0.1, CacheWriteRate: 1.25, SourceURL: providerTextCachePricingOpenAIURL},
+	{Provider: "openai", Model: "gpt-5.6-sol", CacheReadRate: 0.1, CacheWriteRate: 1.25, SourceURL: providerTextCachePricingOpenAIURL},
+	{Provider: "openai", Model: "gpt-5.6-terra", CacheReadRate: 0.1, CacheWriteRate: 1.25, SourceURL: providerTextCachePricingOpenAIURL},
+	{Provider: "openai", Model: "gpt-5.6-luna", CacheReadRate: 0.1, CacheWriteRate: 1.25, SourceURL: providerTextCachePricingOpenAIURL},
 
 	// Anthropic prompt caching prices 5-minute cache writes at 1.25x input and
 	// cache hits at 0.1x input for the Claude models tracked here.

--- a/web/package.json
+++ b/web/package.json
@@ -4,7 +4,7 @@
   "private": true,
   "dependencies": {
     "@ant-design/icons": "^6.2.2",
-    "@yeying-community/web3-bs": "^1.0.11",
+    "@yeying-community/web3-bs": "1.0.16",
     "antd": "^6.3.7",
     "axios": "^0.27.2",
     "history": "^5.3.0",
@@ -23,9 +23,10 @@
   },
   "scripts": {
     "start": "vite",
-    "check": "npm run test:write-paged-rows && npm run check:router-ui && npm run check:popover-safety && vite build",
+    "check": "npm run test:write-paged-rows && npm run test:wallet-session && npm run check:router-ui && npm run check:popover-safety && vite build",
     "build": "node ./scripts/check-router-ui-boundary.mjs && node ./scripts/check-popover-select-safety.mjs && vite build",
     "test:write-paged-rows": "node ./tests/write-paged-rows.test.mjs",
+    "test:wallet-session": "node ./tests/wallet-session.test.mjs",
     "check:router-ui": "node ./scripts/check-router-ui-boundary.mjs",
     "check:popover-safety": "node ./scripts/check-popover-select-safety.mjs",
     "dev": "vite",

--- a/web/src/App.jsx
+++ b/web/src/App.jsx
@@ -15,7 +15,10 @@ import { UserContext } from './context/User';
 import { StatusContext } from './context/Status';
 import { WEB3_TOKEN_STORAGE_KEY } from './helpers/web3';
 import { buildLoginPath } from './helpers/authRedirect';
-import { logoutWallet } from './services/web3Auth';
+import {
+  logoutWallet,
+  restoreWalletSession,
+} from './services/web3Auth';
 import { useWalletProviderStatus } from './hooks/useWalletProviderStatus';
 import AdminLayout from './layouts/AdminLayout';
 import UserLayout from './layouts/UserLayout';
@@ -259,6 +262,7 @@ function App() {
   const navigate = useNavigate();
   const location = useLocation();
   const walletDisconnectTimerRef = useRef(null);
+  const walletSessionRecoveryRef = useRef(null);
 
   const clearWalletSession = useCallback(
     async () => {
@@ -305,17 +309,58 @@ function App() {
     walletDisconnectTimerRef.current = null;
   }, []);
 
+  const recoverWalletSession = useCallback(async () => {
+    if (!isWalletSessionActive()) {
+      return false;
+    }
+    if (walletSessionRecoveryRef.current) {
+      return walletSessionRecoveryRef.current;
+    }
+    const task = (async () => {
+      try {
+        const restored = await restoreWalletSession();
+        if (!restored?.token) {
+          return false;
+        }
+        try {
+          const user = JSON.parse(localStorage.getItem('user') || '{}');
+          if (user?.id) {
+            userDispatch({
+              type: 'login',
+              payload: {
+                ...user,
+                token: restored.token,
+              },
+            });
+          }
+        } catch (error) {
+          // The SDK token remains usable even if the legacy user cache is malformed.
+        }
+        return true;
+      } catch (error) {
+        return false;
+      }
+    })();
+    walletSessionRecoveryRef.current = task;
+    try {
+      return await task;
+    } finally {
+      walletSessionRecoveryRef.current = null;
+    }
+  }, [isWalletSessionActive, userDispatch]);
+
   const handleWalletDisconnected = useCallback(() => {
     if (!isWalletSessionActive() || walletDisconnectTimerRef.current) {
       return;
     }
-    walletDisconnectTimerRef.current = window.setTimeout(() => {
+    walletDisconnectTimerRef.current = window.setTimeout(async () => {
       walletDisconnectTimerRef.current = null;
-      if (isWalletSessionActive()) {
+      const recovered = await recoverWalletSession();
+      if (!recovered && isWalletSessionActive()) {
         clearWalletSession().then();
       }
     }, 2200);
-  }, [clearWalletSession, isWalletSessionActive]);
+  }, [clearWalletSession, isWalletSessionActive, recoverWalletSession]);
 
   const handleWalletAccountsChanged = useCallback(
     (accounts) => {
@@ -404,6 +449,30 @@ function App() {
       }
     }
   }, [loadUser, loadStatus]);
+
+  useEffect(() => {
+    if (!isWalletSessionActive()) {
+      return undefined;
+    }
+    const recover = () => {
+      if (
+        document.visibilityState &&
+        document.visibilityState !== 'visible'
+      ) {
+        return;
+      }
+      recoverWalletSession().then();
+    };
+    recover();
+    window.addEventListener('focus', recover);
+    document.addEventListener('visibilitychange', recover);
+    const timer = window.setInterval(recover, 10 * 60 * 1000);
+    return () => {
+      window.removeEventListener('focus', recover);
+      document.removeEventListener('visibilitychange', recover);
+      window.clearInterval(timer);
+    };
+  }, [isWalletSessionActive, location.pathname, recoverWalletSession]);
 
   useEffect(() => {
     return () => {

--- a/web/src/helpers/walletSession.mjs
+++ b/web/src/helpers/walletSession.mjs
@@ -1,0 +1,38 @@
+export const ACCESS_TOKEN_RENEW_SKEW_MS = 5 * 60 * 1000;
+
+function decodeBase64Url(value) {
+  if (typeof value !== 'string' || typeof globalThis.atob !== 'function') {
+    return '';
+  }
+  const normalized = value.replace(/-/g, '+').replace(/_/g, '/');
+  const padded = normalized.padEnd(Math.ceil(normalized.length / 4) * 4, '=');
+  return globalThis.atob(padded);
+}
+
+export function getAccessTokenExpiresAt(token) {
+  if (typeof token !== 'string' || token.trim() === '') {
+    return 0;
+  }
+  const parts = token.split('.');
+  if (parts.length < 2) {
+    return 0;
+  }
+  try {
+    const payload = JSON.parse(decodeBase64Url(parts[1]));
+    const expiresAtSeconds = Number(payload?.exp || 0);
+    return Number.isFinite(expiresAtSeconds) && expiresAtSeconds > 0
+      ? expiresAtSeconds * 1000
+      : 0;
+  } catch (error) {
+    return 0;
+  }
+}
+
+export function isAccessTokenFresh(
+  token,
+  now = Date.now(),
+  renewSkewMs = ACCESS_TOKEN_RENEW_SKEW_MS,
+) {
+  const expiresAt = getAccessTokenExpiresAt(token);
+  return expiresAt > now + renewSkewMs;
+}

--- a/web/src/services/web3Auth.jsx
+++ b/web/src/services/web3Auth.jsx
@@ -15,8 +15,50 @@ import {
 } from '@yeying-community/web3-bs';
 
 import { WEB3_AUTH_OPTIONS, WEB3_TOKEN_STORAGE_KEY } from '../helpers/web3';
+import {
+  getAccessTokenExpiresAt,
+  isAccessTokenFresh,
+} from '../helpers/walletSession.mjs';
 
 const WALLET_RECONNECT_TIMEOUT_MS = 1600;
+
+function getRefreshPayload(refreshResult) {
+  return refreshResult?.response?.data || refreshResult?.response || {};
+}
+
+function persistRefreshedWalletSession(refreshResult) {
+  const token = refreshResult?.token;
+  if (!token || typeof window === 'undefined') {
+    return;
+  }
+  const payload = getRefreshPayload(refreshResult);
+  const expiresAt =
+    Number(payload?.expiresAt || 0) || getAccessTokenExpiresAt(token);
+  if (expiresAt > 0) {
+    localStorage.setItem(
+      'wallet_token_expires_at',
+      new Date(expiresAt).toISOString(),
+    );
+  }
+  try {
+    const storedUserRaw = localStorage.getItem('user');
+    if (!storedUserRaw) {
+      return;
+    }
+    const storedUser = JSON.parse(storedUserRaw);
+    if (storedUser?.id) {
+      localStorage.setItem(
+        'user',
+        JSON.stringify({
+          ...storedUser,
+          token,
+        }),
+      );
+    }
+  } catch (error) {
+    // Keep the refreshed SDK token even if the legacy user cache is malformed.
+  }
+}
 
 export function normalizeChainId(chainId) {
   if (!chainId) return '';
@@ -134,7 +176,24 @@ export function getStoredAccessToken() {
 }
 
 export async function refreshWalletAccessToken() {
-  return sdkRefreshAccessToken(WEB3_AUTH_OPTIONS);
+  const result = await sdkRefreshAccessToken(WEB3_AUTH_OPTIONS);
+  persistRefreshedWalletSession(result);
+  return result;
+}
+
+export async function restoreWalletSession() {
+  const token = getStoredAccessToken();
+  if (isAccessTokenFresh(token)) {
+    return {
+      token,
+      refreshed: false,
+    };
+  }
+  const result = await refreshWalletAccessToken();
+  return {
+    ...result,
+    refreshed: true,
+  };
 }
 
 export async function logoutWallet() {

--- a/web/tests/wallet-session.test.mjs
+++ b/web/tests/wallet-session.test.mjs
@@ -1,0 +1,42 @@
+import assert from 'node:assert/strict';
+import {
+  ACCESS_TOKEN_RENEW_SKEW_MS,
+  getAccessTokenExpiresAt,
+  isAccessTokenFresh,
+} from '../src/helpers/walletSession.mjs';
+
+function createToken(expiresAtMs) {
+  const encode = (value) =>
+    Buffer.from(JSON.stringify(value))
+      .toString('base64url')
+      .replace(/=+$/, '');
+  return `${encode({ alg: 'HS256', typ: 'JWT' })}.${encode({
+    exp: Math.floor(expiresAtMs / 1000),
+  })}.signature`;
+}
+
+const now = 1_800_000_000_000;
+const freshToken = createToken(now + ACCESS_TOKEN_RENEW_SKEW_MS + 60_000);
+const expiringToken = createToken(now + ACCESS_TOKEN_RENEW_SKEW_MS - 1_000);
+
+assert.equal(
+  getAccessTokenExpiresAt(freshToken),
+  Math.floor((now + ACCESS_TOKEN_RENEW_SKEW_MS + 60_000) / 1000) * 1000,
+);
+assert.equal(
+  isAccessTokenFresh(freshToken, now),
+  true,
+  'wallet disconnect should preserve a still-valid Router session',
+);
+assert.equal(
+  isAccessTokenFresh(expiringToken, now),
+  false,
+  'a token near expiry should be refreshed before preserving the session',
+);
+assert.equal(
+  isAccessTokenFresh('not-a-jwt', now),
+  false,
+  'malformed tokens must not be treated as active sessions',
+);
+
+console.log('wallet session tests passed');


### PR DESCRIPTION
## Summary\n- add GPT-5.6 family OpenAI provider migration rows\n- add GPT-5.6 cache pricing component rules\n- refresh existing OpenAI provider rows via versioned migration\n\n## Verification\n- go test ./internal/admin/model -run 'TestBuildProviderMigrationSeeds_OpenAIIncludesGPT5xPricing|TestBuildProviderMigrationSeeds_OpenAIIncludesGPT55Pricing|TestBuildProviderMigrationSeeds_OpenAIIncludesGPT56AliasPricing|TestBuildProviderMigrationSeeds_OpenAIIncludesNewOfficialModels|TestUpsertProviderTextCachePricingComponentsWithDB|TestUpsertProviderMigrationProvidersPreservesTextCachePricingComponents|TestUpsertProviderMigrationProvidersPrunesStaleMigrationModelsOnlyForTargetProvider'