### PR TITLE
Disable quota exhausted model endpoints

### DIFF
--- a/internal/admin/controller/relay.go
+++ b/internal/admin/controller/relay.go
@@ -502,6 +502,10 @@ func processChannelRelayError(ctx context.Context, userId string, groupID string
 			Build())
 		return
 	}
+	if isUpstreamQuotaRelayError(&err) {
+		disableUpstreamQuotaChannelModelEndpoint(ctx, channelId, channelName, requestModel, requestPath, err)
+		return
+	}
 	if shouldDisableChannelModelRequestEndpointCapability(&err) {
 		disabled, disableErr := dbmodel.DisableChannelModelRequestEndpointCapabilityWithReason(channelId, requestModel, requestPath, err.Message, "runtime")
 		logChannelModelRequestEndpointDisableResult(ctx, channelId, channelName, requestModel, requestPath, err, disabled, disableErr)
@@ -527,17 +531,34 @@ func processChannelRelayError(ctx context.Context, userId string, groupID string
 	if shouldRuntimeDisableChannelModelEndpointAfterRepeatedFailures(ctx, channelId, channelName, requestModel, requestPath, err) {
 		return
 	}
-	if monitor.IsInsufficientBalanceError(&err.Error, err.StatusCode) {
-		if disableErr := monitor.DisableChannelForInsufficientBalance(channelId, channelName, 0); disableErr != nil {
-			monitor.Emit(channelId, false)
-		}
-		return
-	}
 	if monitor.ShouldDisableChannel(&err.Error, err.StatusCode) {
 		monitor.DisableChannel(channelId, channelName, err.Message)
 	} else {
 		monitor.Emit(channelId, false)
 	}
+}
+
+func disableUpstreamQuotaChannelModelEndpoint(ctx context.Context, channelId string, channelName string, requestModel string, requestPath string, err model.ErrorWithStatusCode) {
+	normalizedEndpoint := dbmodel.NormalizeRequestedChannelModelEndpoint(requestPath)
+	reason := upstreamQuotaEndpointDisableReason(err)
+	disabled, disableErr := dbmodel.DisableChannelModelRequestEndpointCapabilityWithReason(channelId, requestModel, normalizedEndpoint, reason, "runtime")
+	logChannelModelRequestEndpointDisableResult(ctx, channelId, channelName, requestModel, normalizedEndpoint, err, disabled, disableErr)
+	if disableErr != nil {
+		monitor.Emit(channelId, false)
+		return
+	}
+	if disabled {
+		monitor.NotifyChannelModelEndpointCapabilityDisabled(channelId, channelName, requestModel, normalizedEndpoint, reason)
+		enqueueChannelModelCapabilityRecoveryTest(ctx, channelId, requestModel, normalizedEndpoint)
+	}
+}
+
+func upstreamQuotaEndpointDisableReason(err model.ErrorWithStatusCode) string {
+	message := strings.TrimSpace(err.Message)
+	if message == "" {
+		message = "上游返回额度或余额不足"
+	}
+	return "上游额度不足，运行时禁用该模型端点：" + message
 }
 
 func shouldRuntimeDisableChannelModelEndpointAfterRepeatedFailures(ctx context.Context, channelId string, channelName string, requestModel string, requestPath string, err model.ErrorWithStatusCode) bool {

--- a/internal/admin/controller/relay_status_test.go
+++ b/internal/admin/controller/relay_status_test.go
@@ -188,6 +188,40 @@ func TestNormalizeFinalRelayErrorForUpstreamQuotaExhausted(t *testing.T) {
 	}
 }
 
+func TestIsUpstreamQuotaRelayErrorForDailyLimitExceeded(t *testing.T) {
+	err := &relaymodel.ErrorWithStatusCode{
+		StatusCode: http.StatusPaymentRequired,
+		Error: relaymodel.Error{
+			Message: "每日额度超限：当前 $50.1702 USD（限制：$50.0000 USD）。将于 2026年07月14日 00:00:00 重置",
+			Type:    "rate_limit_error",
+			Code:    "rate_limit_exceeded",
+		},
+	}
+
+	if !isUpstreamQuotaRelayError(err) {
+		t.Fatalf("isUpstreamQuotaRelayError = false, want true for upstream daily limit exceeded")
+	}
+	if shouldTrackRuntimeCapabilityFailure(err) {
+		t.Fatalf("shouldTrackRuntimeCapabilityFailure = true, want false for upstream quota endpoint disable path")
+	}
+}
+
+func TestUpstreamQuotaEndpointDisableReasonIncludesProviderMessage(t *testing.T) {
+	err := relaymodel.ErrorWithStatusCode{
+		StatusCode: http.StatusPaymentRequired,
+		Error: relaymodel.Error{
+			Message: "每日额度超限：当前 $50.1702 USD",
+			Type:    "rate_limit_error",
+			Code:    "rate_limit_exceeded",
+		},
+	}
+
+	got := upstreamQuotaEndpointDisableReason(err)
+	if got != "上游额度不足，运行时禁用该模型端点：每日额度超限：当前 $50.1702 USD" {
+		t.Fatalf("unexpected reason: %q", got)
+	}
+}
+
 func TestNormalizeFinalRelayErrorForZhipuInsufficientBalanceCode(t *testing.T) {
 	err := &relaymodel.ErrorWithStatusCode{
 		StatusCode: http.StatusTooManyRequests,

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -1,0 +1,141 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+repo_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+deploy_dir="${ROUTER_DEPLOY_DIR:-/opt/deploy/router}"
+build_dir="$repo_dir/build"
+build_binary="$build_dir/router"
+web_dir="$repo_dir/web"
+target_binary="$deploy_dir/build/router"
+starter="$deploy_dir/scripts/starter.sh"
+pid_file="$deploy_dir/run/router.pid"
+backup_binary=""
+service_stopped=false
+build_web="${ROUTER_BUILD_WEB:-1}"
+
+log() {
+  printf '[deploy] %s\n' "$*"
+}
+
+die() {
+  printf '[deploy] ERROR: %s\n' "$*" >&2
+  exit 1
+}
+
+usage() {
+  cat <<'USAGE'
+Usage: scripts/deploy.sh [--skip-web]
+
+Builds the embedded web frontend by default, then builds and deploys router.
+
+Options:
+  --skip-web      Skip npm install/build and use the existing web/dist assets.
+
+Environment:
+  ROUTER_BUILD_WEB=0              Skip frontend build.
+  ROUTER_DEPLOY_DIR=/opt/deploy/router
+  ROUTER_STARTUP_WAIT_SECONDS=3
+USAGE
+}
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --skip-web)
+      build_web=0
+      shift
+      ;;
+    --help|-h)
+      usage
+      exit 0
+      ;;
+    *)
+      die "unknown argument: $1"
+      ;;
+  esac
+done
+
+rollback() {
+  local status=$?
+
+  if [[ "$service_stopped" == true ]]; then
+    printf '[deploy] Deployment failed, attempting rollback.\n' >&2
+    if [[ -n "$backup_binary" && -f "$backup_binary" ]]; then
+      cp "$backup_binary" "$target_binary"
+      chmod 0755 "$target_binary"
+      printf '[deploy] Restored %s\n' "$backup_binary" >&2
+    fi
+    "$starter" start || true
+  fi
+
+  exit "$status"
+}
+
+trap rollback ERR
+
+[[ -x "$starter" ]] || die "starter script not found or not executable: $starter"
+command -v go >/dev/null 2>&1 || die "go command not found"
+
+if [[ "$build_web" != "0" && "$build_web" != "false" && "$build_web" != "no" ]]; then
+  [[ -d "$web_dir" ]] || die "web directory not found: $web_dir"
+  [[ -f "$web_dir/package.json" ]] || die "web package.json not found: $web_dir/package.json"
+  command -v npm >/dev/null 2>&1 || die "npm command not found"
+
+  log "Building web frontend from $web_dir"
+  (
+    cd "$web_dir"
+    if [[ -f package-lock.json ]]; then
+      npm ci
+    else
+      npm install
+    fi
+    npm run build
+  )
+else
+  log "Skipping web frontend build"
+fi
+
+[[ -f "$web_dir/dist/index.html" ]] || die "web dist index not found: $web_dir/dist/index.html"
+
+log "Building router from $repo_dir"
+mkdir -p "$build_dir"
+(
+  cd "$repo_dir"
+  go build -o "$build_binary" ./cmd/router
+)
+[[ -x "$build_binary" ]] || die "build output is not executable: $build_binary"
+
+if command -v sha256sum >/dev/null 2>&1; then
+  log "Built binary: $(sha256sum "$build_binary" | awk '{print $1}')"
+fi
+
+log "Stopping router"
+"$starter" stop
+service_stopped=true
+
+mkdir -p "$(dirname "$target_binary")"
+if [[ -f "$target_binary" ]]; then
+  backup_binary="${target_binary}.bak.$(date +%Y%m%d%H%M%S)"
+  cp "$target_binary" "$backup_binary"
+  log "Backed up current binary to $backup_binary"
+fi
+
+log "Replacing production binary"
+install -m 0755 "$build_binary" "${target_binary}.new"
+mv -f "${target_binary}.new" "$target_binary"
+
+log "Starting router"
+"$starter" start
+sleep "${ROUTER_STARTUP_WAIT_SECONDS:-3}"
+
+[[ -f "$pid_file" ]] || die "router pid file was not created: $pid_file"
+pid="$(cat "$pid_file")"
+[[ -n "$pid" ]] || die "router pid file is empty: $pid_file"
+kill -0 "$pid" 2>/dev/null || die "router process is not running: pid $pid"
+
+service_stopped=false
+trap - ERR
+
+log "Router deployment completed successfully, pid $pid"
+if command -v sha256sum >/dev/null 2>&1; then
+  log "Deployed binary: $(sha256sum "$target_binary" | awk '{print $1}')"
+fi


### PR DESCRIPTION
## Summary
- disable only the specific channel/model/endpoint when a real upstream quota or balance exhaustion error occurs during relay
- keep flaky accounting refresh advisory-only instead of disabling whole channels
- add deploy script that builds embedded web assets by default, with --skip-web / ROUTER_BUILD_WEB=0 opt-out

## Tests
- go test ./internal/admin/controller -run 'Test.*(Relay|RuntimeCapability|UpstreamQuota|Quota|UnsupportedEndpoint|ShouldRetry)' -count=1
- go test ./internal/admin/model -run 'Test.*(ChannelModelEndpoint|RuntimeDisabled|DisableTransitions)' -count=1
- bash -n scripts/deploy.sh
