### PR TITLE
Fix channel procurement purchase editing

### DIFF
--- a/internal/admin/controller/channel/billing_resource.go
+++ b/internal/admin/controller/channel/billing_resource.go
@@ -68,6 +68,7 @@ type channelBillingManualSnapshotRequest struct {
 }
 
 type channelBillingManualQuotaItemRequest struct {
+	Id              string  `json:"id"`
 	ResourceType    string  `json:"resource_type"`
 	QuotaType       string  `json:"quota_type"`
 	QuotaLabel      string  `json:"quota_label"`
@@ -662,6 +663,181 @@ func maskBillingSecret(value string) string {
 	return trimmed[:3] + "***" + trimmed[len(trimmed)-3:]
 }
 
+func nearlyEqualFloat(left float64, right float64) bool {
+	if left > right {
+		return left-right < 0.0000001
+	}
+	return right-left < 0.0000001
+}
+
+func ensureConsumedSnapshotImmutableFields(current model.ChannelBillingSnapshot, next normalizedManualBillingSnapshotRequest) error {
+	if current.PurchaseAt != next.PurchaseAt ||
+		strings.TrimSpace(strings.ToUpper(current.PurchaseCurrency)) != strings.TrimSpace(strings.ToUpper(next.PurchaseCurrency)) ||
+		!nearlyEqualFloat(current.PurchaseAmount, next.PurchaseAmount) ||
+		!nearlyEqualFloat(current.PurchaseFXRate, next.PurchaseFXRate) ||
+		!nearlyEqualFloat(current.PurchaseCostAmount, next.PurchaseCostAmount) {
+		return fmt.Errorf("该采购记录已经被消耗，只能修正权益类型、有效期、名称和备注")
+	}
+	return nil
+}
+
+func sumProcurementConsumedQuantityWithDB(tx *gorm.DB, batchID string) (float64, error) {
+	normalizedBatchID := strings.TrimSpace(batchID)
+	if normalizedBatchID == "" {
+		return 0, nil
+	}
+	var consumed float64
+	err := tx.Model(&model.RequestProcurementConsumption{}).
+		Where("procurement_batch_id = ?", normalizedBatchID).
+		Select("COALESCE(SUM(consumed_quantity), 0)").
+		Scan(&consumed).Error
+	return consumed, err
+}
+
+func updateConsumedManualBillingSnapshotWithDB(tx *gorm.DB, current model.ChannelBillingSnapshot, channelID string, req normalizedManualBillingSnapshotRequest, operatorUserID string) ([]model.ChannelBillingSnapshotItem, error) {
+	if err := ensureConsumedSnapshotImmutableFields(current, req); err != nil {
+		return nil, err
+	}
+	existingItems := model.NormalizeChannelBillingSnapshotItems(current.Items)
+	if len(existingItems) != len(req.Items) {
+		return nil, fmt.Errorf("该采购记录已经被消耗，不能新增或删除权益项")
+	}
+	itemsByID := make(map[string]model.ChannelBillingSnapshotItem, len(existingItems))
+	for _, item := range existingItems {
+		if strings.TrimSpace(item.Id) != "" {
+			itemsByID[strings.TrimSpace(item.Id)] = item
+		}
+	}
+	updatedSnapshot, err := model.UpdateChannelBillingSnapshotPurchaseWithDB(tx, model.ChannelBillingSnapshot{
+		Id:                 current.Id,
+		ChannelId:          channelID,
+		PurchaseAt:         req.PurchaseAt,
+		PurchaseCurrency:   req.PurchaseCurrency,
+		PurchaseAmount:     req.PurchaseAmount,
+		PurchaseFXRate:     req.PurchaseFXRate,
+		PurchaseCostAmount: req.PurchaseCostAmount,
+		EntitlementName:    req.EntitlementName,
+		ValidFrom:          req.ValidFrom,
+		ValidUntil:         req.ValidUntil,
+		Message:            req.Message,
+		OperatorUserId:     operatorUserID,
+	})
+	if err != nil {
+		return nil, err
+	}
+	now := helper.GetTimestamp()
+	updatedItems := make([]model.ChannelBillingSnapshotItem, 0, len(req.Items))
+	for index, nextItem := range req.Items {
+		currentItem := model.ChannelBillingSnapshotItem{}
+		if itemID := strings.TrimSpace(nextItem.Id); itemID != "" {
+			matched, ok := itemsByID[itemID]
+			if !ok {
+				return nil, fmt.Errorf("该采购记录已经被消耗，权益项不存在")
+			}
+			currentItem = matched
+		} else {
+			currentItem = existingItems[index]
+		}
+		if strings.TrimSpace(currentItem.ResourceType) != strings.TrimSpace(nextItem.ResourceType) ||
+			strings.TrimSpace(strings.ToUpper(currentItem.Currency)) != strings.TrimSpace(strings.ToUpper(nextItem.Currency)) ||
+			!nearlyEqualFloat(currentItem.Amount, nextItem.Amount) ||
+			!nearlyEqualFloat(currentItem.LimitAmount, nextItem.LimitAmount) ||
+			!nearlyEqualFloat(currentItem.UsedAmount, nextItem.UsedAmount) ||
+			!nearlyEqualFloat(currentItem.RemainingAmount, nextItem.RemainingAmount) {
+			return nil, fmt.Errorf("该采购记录已经被消耗，不能修改权益容量或币种")
+		}
+		nextItem.Id = currentItem.Id
+		nextItem.SnapshotId = current.Id
+		nextItem.ChannelId = channelID
+		nextItem.CreatedAt = currentItem.CreatedAt
+		nextItem.SortOrder = currentItem.SortOrder
+		if nextItem.SortOrder == 0 {
+			nextItem.SortOrder = index + 1
+		}
+		if err := tx.Model(&model.ChannelBillingSnapshotItem{}).
+			Where("id = ? AND snapshot_id = ?", currentItem.Id, current.Id).
+			Updates(map[string]any{
+				"quota_type":       strings.TrimSpace(strings.ToLower(nextItem.QuotaType)),
+				"quota_label":      strings.TrimSpace(nextItem.QuotaLabel),
+				"reset_at":         nextItem.ResetAt,
+				"expires_at":       nextItem.ExpiresAt,
+				"source_ref":       strings.TrimSpace(nextItem.SourceRef),
+				"sort_order":       nextItem.SortOrder,
+				"resource_type":    strings.TrimSpace(strings.ToLower(nextItem.ResourceType)),
+				"amount":           nextItem.Amount,
+				"limit_amount":     nextItem.LimitAmount,
+				"used_amount":      nextItem.UsedAmount,
+				"remaining_amount": nextItem.RemainingAmount,
+				"currency":         strings.TrimSpace(strings.ToUpper(nextItem.Currency)),
+			}).Error; err != nil {
+			return nil, err
+		}
+		batchTemplate, ok := model.BuildProcurementBatchFromBillingSnapshotItem(updatedSnapshot, nextItem)
+		if !ok {
+			return nil, fmt.Errorf("该采购记录已经被消耗，不能移除可消耗权益项")
+		}
+		batches, err := model.ListChannelProcurementBatchesBySourceSnapshotIDWithDB(tx, current.Id)
+		if err != nil {
+			return nil, err
+		}
+		for _, batch := range batches {
+			if strings.TrimSpace(batch.SourceSnapshotItemId) != strings.TrimSpace(currentItem.Id) {
+				continue
+			}
+			consumed, err := sumProcurementConsumedQuantityWithDB(tx, batch.Id)
+			if err != nil {
+				return nil, err
+			}
+			capacityRemaining := batchTemplate.CapacityEffective - consumed
+			if capacityRemaining < 0 {
+				capacityRemaining = 0
+			}
+			costStatus := batch.CostStatus
+			if costStatus != model.ProcurementCostStatusDisabled && costStatus != model.ProcurementCostStatusCostUnconfigured {
+				if capacityRemaining <= 0 {
+					costStatus = model.ProcurementCostStatusExhausted
+				} else {
+					costStatus = model.ProcurementCostStatusActive
+				}
+			}
+			costPerUnitAmount := batch.CostPerUnitAmount
+			if batch.PurchaseCostAmount > 0 && batchTemplate.CapacityEffective > 0 {
+				costPerUnitAmount = batch.PurchaseCostAmount / batchTemplate.CapacityEffective
+			}
+			windowRemaining := batchTemplate.CapacityTotal - consumed
+			if windowRemaining < 0 {
+				windowRemaining = 0
+			}
+			updates := map[string]any{
+				"resource_type":        batchTemplate.ResourceType,
+				"quota_type":           batchTemplate.QuotaType,
+				"capacity_total":       batchTemplate.CapacityTotal,
+				"capacity_effective":   batchTemplate.CapacityEffective,
+				"capacity_remaining":   capacityRemaining,
+				"cost_per_unit_amount": costPerUnitAmount,
+				"valid_from":           batchTemplate.ValidFrom,
+				"expire_at":            batchTemplate.ExpireAt,
+				"reset_cycle":          batchTemplate.ResetCycle,
+				"window_started_at":    batchTemplate.WindowStartedAt,
+				"window_remaining":     windowRemaining,
+				"source_ref":           batchTemplate.SourceRef,
+				"metadata":             batchTemplate.Metadata,
+				"cost_status":          costStatus,
+				"updated_at":           now,
+			}
+			if batchTemplate.ResetCycle == "none" || batchTemplate.ResetCycle == "" {
+				updates["window_started_at"] = int64(0)
+				updates["window_remaining"] = float64(0)
+			}
+			if err := tx.Model(&model.ChannelProcurementBatch{}).Where("id = ?", batch.Id).Updates(updates).Error; err != nil {
+				return nil, err
+			}
+		}
+		updatedItems = append(updatedItems, nextItem)
+	}
+	return model.NormalizeChannelBillingSnapshotItems(updatedItems), nil
+}
+
 type normalizedManualBillingSnapshotRequest struct {
 	PurchaseAt         int64
 	PurchaseCurrency   string
@@ -772,6 +948,7 @@ func normalizeManualBillingSnapshotRequest(req channelBillingManualSnapshotReque
 			sourceRef = "manual"
 		}
 		quotaItems = append(quotaItems, model.ChannelBillingSnapshotItem{
+			Id:              strings.TrimSpace(item.Id),
 			ResourceType:    resourceType,
 			QuotaType:       quotaType,
 			QuotaLabel:      quotaLabel,
@@ -917,7 +1094,22 @@ func UpdateChannelBillingSnapshot(c *gin.Context) {
 			return err
 		}
 		if count > 0 {
-			return fmt.Errorf("该采购记录已经被消耗，不能修改")
+			updatedItems, err := updateConsumedManualBillingSnapshotWithDB(tx, current, channelRow.Id, normalizedReq, operatorUserID)
+			if err != nil {
+				return err
+			}
+			_, err = model.CreateChannelBillingActionWithDB(tx, model.ChannelBillingAction{
+				ChannelId:      channelRow.Id,
+				ActionType:     model.ChannelBillingActionTypeManualUpdateSnapshot,
+				Status:         model.ChannelBillingActionStatusDone,
+				RequestPayload: marshalLogJSON(req),
+				ResultPayload:  marshalLogJSON(map[string]any{"items": updatedItems, "consumed_metadata_update": true}),
+				Message:        normalizedReq.Message,
+				OperatorUserId: operatorUserID,
+				CreatedAt:      now,
+				UpdatedAt:      now,
+			})
+			return err
 		}
 		updatedSnapshot, err := model.UpdateChannelBillingSnapshotPurchaseWithDB(tx, model.ChannelBillingSnapshot{
 			Id:                 current.Id,

--- a/web/src/locales/en/translation.json
+++ b/web/src/locales/en/translation.json
@@ -1002,7 +1002,7 @@
           "created_at": "Time",
           "purchase_at": "Purchase Time",
           "purchase_amount": "Paid Amount",
-          "purchase_cost_amount": "Purchase Cost CNY",
+          "purchase_cost_amount": "Purchase Cost",
           "entitlement_name": "Entitlement Name",
           "validity": "Validity",
           "source_type": "Source",

--- a/web/src/locales/zh/translation.json
+++ b/web/src/locales/zh/translation.json
@@ -1002,7 +1002,7 @@
           "created_at": "时间",
           "purchase_at": "采购时间",
           "purchase_amount": "实付金额",
-          "purchase_cost_amount": "采购成本 CNY",
+          "purchase_cost_amount": "采购成本",
           "entitlement_name": "权益名称",
           "validity": "有效期",
           "source_type": "来源",

--- a/web/src/pages/Channel/ChannelForm.jsx
+++ b/web/src/pages/Channel/ChannelForm.jsx
@@ -675,9 +675,13 @@ const normalizeChannelBillingSnapshots = (items) => {
       purchase_amount: Number(item.purchase_amount || 0),
       purchase_fx_rate: Number(item.purchase_fx_rate || 0),
       purchase_cost_amount: Number(item.purchase_cost_amount || 0),
+      entitlement_name: (item.entitlement_name || '').toString(),
+      valid_from: Number(item.valid_from || 0),
+      valid_until: Number(item.valid_until || 0),
       created_at: Number(item.created_at || 0),
       items: Array.isArray(item.items)
         ? item.items.map((quotaItem) => ({
+            id: (quotaItem?.id || '').toString().trim(),
             resource_type: (quotaItem?.resource_type || '').toString().trim(),
             quota_type: (quotaItem?.quota_type || '').toString().trim(),
             quota_label: (quotaItem?.quota_label || '').toString().trim(),
@@ -3674,6 +3678,7 @@ const ChannelForm = ({ mode = 'auto' } = {}) => {
       }
       const normalizedItems = (Array.isArray(items) ? items : [])
         .map((item) => ({
+          id: (item?.id || '').toString().trim(),
           resource_type: (item?.resource_type || '').toString().trim(),
           quota_type: (item?.quota_type || '').toString().trim(),
           quota_label: (item?.quota_label || '').toString().trim(),

--- a/web/src/pages/Channel/components/ChannelDetailBillingTab.jsx
+++ b/web/src/pages/Channel/components/ChannelDetailBillingTab.jsx
@@ -526,52 +526,72 @@ const buildProcurementCostDraft = (row) => ({
 });
 
 const toUnixTimestamp = (value) => {
-	const normalized = (value || '').toString().trim();
-	if (normalized === '') {
-		return 0;
-	}
+  const normalized = (value || '').toString().trim();
+  if (normalized === '') {
+    return 0;
+  }
   const parsed = new Date(normalized);
   const millis = parsed.getTime();
   if (!Number.isFinite(millis) || Number.isNaN(millis)) {
     return 0;
   }
-	return Math.floor(millis / 1000);
+  return Math.floor(millis / 1000);
 };
 
 const toDateTimeLocalValueFromTimestamp = (value) => {
-	const timestamp = Number(value || 0);
-	if (timestamp <= 0) {
-		return '';
-	}
-	return toDateTimeLocalValue(new Date(timestamp * 1000));
+  const timestamp = Number(value || 0);
+  if (timestamp <= 0) {
+    return '';
+  }
+  return toDateTimeLocalValue(new Date(timestamp * 1000));
+};
+
+const normalizeManualValidityInput = (value, defaultTime, forceDefaultTime = false) => {
+  const normalized = (value || '').toString().trim();
+  if (normalized === '') {
+    return '';
+  }
+  if (/^\d{4}-\d{2}-\d{2}$/.test(normalized)) {
+    return `${normalized}T${defaultTime}`;
+  }
+  if (/^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}(:\d{2})?$/.test(normalized)) {
+    if (forceDefaultTime) {
+      return `${normalized.slice(0, 10)}T${defaultTime}`;
+    }
+    return normalized.length === 16
+      ? `${normalized}:${defaultTime.slice(-2)}`
+      : normalized;
+  }
+  return normalized;
 };
 
 const buildManualPurchaseRecordFromSnapshot = (row) => ({
-	purchase_at_input:
-		toDateTimeLocalValueFromTimestamp(row?.purchase_at) ||
-		buildManualPurchaseRecord().purchase_at_input,
-	purchase_currency:
-		(row?.purchase_currency || 'CNY').toString().trim().toUpperCase() || 'CNY',
-	purchase_amount: Number(row?.purchase_amount || 0),
-	purchase_fx_rate: Number(row?.purchase_fx_rate || 1) || 1,
-	purchase_cost_amount: Number(row?.purchase_cost_amount || 0),
-	entitlement_name: (row?.entitlement_name || '').toString(),
-	valid_from_input: toDateTimeLocalValueFromTimestamp(row?.valid_from),
-	valid_until_input: toDateTimeLocalValueFromTimestamp(row?.valid_until),
+  purchase_at_input:
+    toDateTimeLocalValueFromTimestamp(row?.purchase_at) ||
+    buildManualPurchaseRecord().purchase_at_input,
+  purchase_currency:
+    (row?.purchase_currency || 'CNY').toString().trim().toUpperCase() || 'CNY',
+  purchase_amount: Number(row?.purchase_amount || 0),
+  purchase_fx_rate: Number(row?.purchase_fx_rate || 1) || 1,
+  purchase_cost_amount: Number(row?.purchase_cost_amount || 0),
+  entitlement_name: (row?.entitlement_name || '').toString(),
+  valid_from_input: toDateTimeLocalValueFromTimestamp(row?.valid_from),
+  valid_until_input: toDateTimeLocalValueFromTimestamp(row?.valid_until),
 });
 
 const buildManualQuotaItemFromSnapshotItem = (item) => ({
-	resource_type: (item?.resource_type || 'quota').toString().trim() || 'quota',
-	quota_type: (item?.quota_type || 'total').toString().trim() || 'total',
-	quota_label: (item?.quota_label || '').toString(),
-	amount: Number(item?.amount || item?.remaining_amount || 0),
-	limit_amount: Number(item?.limit_amount || item?.amount || 0),
-	used_amount: Number(item?.used_amount || 0),
-	remaining_amount: Number(item?.remaining_amount || item?.amount || 0),
-	currency: (item?.currency || 'USD').toString().trim() || 'USD',
-	reset_at_input: toDateTimeLocalValueFromTimestamp(item?.reset_at),
-	expires_at_input: toDateTimeLocalValueFromTimestamp(item?.expires_at),
-	source_ref: (item?.source_ref || 'manual').toString().trim() || 'manual',
+  id: (item?.id || '').toString().trim(),
+  resource_type: (item?.resource_type || 'quota').toString().trim() || 'quota',
+  quota_type: (item?.quota_type || 'total').toString().trim() || 'total',
+  quota_label: (item?.quota_label || '').toString(),
+  amount: Number(item?.amount || item?.remaining_amount || 0),
+  limit_amount: Number(item?.limit_amount || item?.amount || 0),
+  used_amount: Number(item?.used_amount || 0),
+  remaining_amount: Number(item?.remaining_amount || item?.amount || 0),
+  currency: (item?.currency || 'USD').toString().trim() || 'USD',
+  reset_at_input: toDateTimeLocalValueFromTimestamp(item?.reset_at),
+  expires_at_input: toDateTimeLocalValueFromTimestamp(item?.expires_at),
+  source_ref: (item?.source_ref || 'manual').toString().trim() || 'manual',
 });
 
 const isPurchaseCurrencyCNY = (record) =>
@@ -610,6 +630,10 @@ const ChannelDetailBillingTab = ({
   const [consumptionRows, setConsumptionRows] = useState([]);
   const [consumptionLoading, setConsumptionLoading] = useState(false);
   const [viewingProcurementBatch, setViewingProcurementBatch] = useState(null);
+  const [manualValidityTouched, setManualValidityTouched] = useState({
+    valid_from_input: false,
+    valid_until_input: false,
+  });
   const [billingView, setBillingView] = useState('records');
 
   const purchaseRecords = useMemo(
@@ -667,6 +691,19 @@ const ChannelDetailBillingTab = ({
     }));
   };
 
+  const updateManualValidityInput = (field, value, defaultTime) => {
+    const firstTouch = manualValidityTouched[field] !== true;
+    updateManualPurchaseRecord({
+      [field]: normalizeManualValidityInput(value, defaultTime, firstTouch),
+    });
+    if (firstTouch) {
+      setManualValidityTouched((prev) => ({
+        ...prev,
+        [field]: true,
+      }));
+    }
+  };
+
   const closeManualModal = () => {
     if (!billingSubmitting) {
       setManualModalOpen(false);
@@ -677,6 +714,10 @@ const ChannelDetailBillingTab = ({
   const openCreateManualModal = () => {
     setEditingPurchaseRecord(null);
     setManualPurchaseRecord(buildManualPurchaseRecord());
+    setManualValidityTouched({
+      valid_from_input: false,
+      valid_until_input: false,
+    });
     setManualMessage('');
     setManualItems([buildManualQuotaItem()]);
     setManualModalOpen(true);
@@ -685,6 +726,10 @@ const ChannelDetailBillingTab = ({
   const openEditManualModal = (row) => {
     setEditingPurchaseRecord(row);
     setManualPurchaseRecord(buildManualPurchaseRecordFromSnapshot(row));
+    setManualValidityTouched({
+      valid_from_input: true,
+      valid_until_input: true,
+    });
     setManualMessage((row?.message || '').toString());
     const items = Array.isArray(row?.items) ? row.items : [];
     setManualItems(
@@ -761,13 +806,14 @@ const ChannelDetailBillingTab = ({
       items: manualItems.map((manualItem) => {
         const amounts = resolveManualItemAmounts(manualItem);
         return {
+          id: manualItem.id,
           resource_type: manualItem.resource_type,
           quota_type: manualItem.quota_type,
           quota_label: '',
           ...amounts,
           currency: manualItem.currency,
-          reset_at: 0,
-          expires_at: 0,
+          reset_at: toUnixTimestamp(manualItem.reset_at_input),
+          expires_at: toUnixTimestamp(manualItem.expires_at_input),
           source_ref: 'manual',
         };
       }),
@@ -935,16 +981,36 @@ const ChannelDetailBillingTab = ({
             />
           </AppField>
           <AppField label={t('channel.edit.billing.manual_valid_from')}>
-            <AppInput className='router-section-input' type='datetime-local'
+            <AppInput
+              className='router-section-input'
+              type='datetime-local'
+              step={1}
               value={manualPurchaseRecord.valid_from_input}
-              onChange={(e, { value }) => updateManualPurchaseRecord({ valid_from_input: (value || '').toString() })}
-              readOnly={billingReadonly || billingSubmitting} />
+              onChange={(e, { value }) =>
+                updateManualValidityInput(
+                  'valid_from_input',
+                  value,
+                  '00:00:00'
+                )
+              }
+              readOnly={billingReadonly || billingSubmitting}
+            />
           </AppField>
           <AppField label={t('channel.edit.billing.manual_valid_until')}>
-            <AppInput className='router-section-input' type='datetime-local'
+            <AppInput
+              className='router-section-input'
+              type='datetime-local'
+              step={1}
               value={manualPurchaseRecord.valid_until_input}
-              onChange={(e, { value }) => updateManualPurchaseRecord({ valid_until_input: (value || '').toString() })}
-              readOnly={billingReadonly || billingSubmitting} />
+              onChange={(e, { value }) =>
+                updateManualValidityInput(
+                  'valid_until_input',
+                  value,
+                  '23:59:59'
+                )
+              }
+              readOnly={billingReadonly || billingSubmitting}
+            />
           </AppField>
         </AppFormRow>
       </div>
@@ -1417,7 +1483,7 @@ const ChannelDetailBillingTab = ({
               {
                 title: t('channel.edit.billing.snapshot_table.purchase_amount'),
                 key: 'purchase_amount',
-                width: 180,
+                width: 130,
                 render: (_, row) =>
                   row?.purchase_amount
                     ? `${formatNumberText(row.purchase_amount, 6)} ${
@@ -1429,7 +1495,7 @@ const ChannelDetailBillingTab = ({
                 title: t('channel.edit.billing.snapshot_table.purchase_cost_amount'),
                 dataIndex: 'purchase_cost_amount',
                 key: 'purchase_cost_amount',
-                width: 160,
+                width: 130,
                 render: (value) =>
                   Number(value || 0) > 0
                     ? `${formatNumberText(value, 6)} CNY`
@@ -1445,7 +1511,7 @@ const ChannelDetailBillingTab = ({
               {
                 title: t('channel.edit.billing.snapshot_table.validity'),
                 key: 'validity',
-                width: 250,
+                width: 330,
                 render: (_, row) => {
                   const start = Number(row?.valid_from || 0) > 0
                     ? timestamp2string(row.valid_from)
@@ -1483,7 +1549,7 @@ const ChannelDetailBillingTab = ({
                 key: 'actions',
                 width: 110,
                 render: (_, row) => (
-                  <AppCompact>
+                  <div className='router-table-actions-icon-compact'>
                     <AppTableActionButton
                       title={t('channel.edit.billing.edit_purchase_record')}
                       icon='edit'
@@ -1509,7 +1575,7 @@ const ChannelDetailBillingTab = ({
                         />
                       </span>
                     </AppPopconfirm>
-                  </AppCompact>
+                  </div>
                 ),
               },
             ]}
@@ -1605,7 +1671,7 @@ const ChannelDetailBillingTab = ({
                 key: 'actions',
                 width: 150,
                 render: (_, row) => (
-                  <AppCompact>
+                  <div className='router-table-actions-icon-compact'>
                     <AppTableActionButton
                       title={t(
                         'channel.edit.billing.procurement_view_consumptions'
@@ -1656,7 +1722,7 @@ const ChannelDetailBillingTab = ({
                         />
                       </AppPopconfirm>
                     )}
-                  </AppCompact>
+                  </div>
                 ),
               },
             ]}


### PR DESCRIPTION
## Summary
- fix channel purchase records to preserve entitlement fields and item ids for edit refill
- improve purchase record table labels, widths, validity defaults, and action spacing
- allow consumed purchase records to correct entitlement type/validity metadata while keeping monetary and capacity fields immutable
- sync corrected purchase metadata into procurement batches, including reset cycle, expiry, capacity, and unit cost

## Tests
- go test ./internal/admin/controller/channel ./internal/admin/model -run 'Test.*(Billing|Procurement|Manual|Snapshot|Consumed)' -count=1
- npm run build
- git diff --check
