### PR TITLE
fix: use health checks for model health strip

### DIFF
--- a/internal/admin/controller/model.go
+++ b/internal/admin/controller/model.go
@@ -695,6 +695,57 @@ func loadUserModelStatusTestRows(channelIDs []string, modelNames []string) (map[
 	return result, nil
 }
 
+func buildUserModelStatusTestHealthAggregates(nowTs int64, rows []model.ChannelTest) []healthtrend.Aggregate {
+	start := healthtrend.WindowStart(nowTs)
+	if start <= 0 || len(rows) == 0 {
+		return []healthtrend.Aggregate{}
+	}
+	byBucket := make(map[int64]*healthtrend.Aggregate)
+	for _, row := range rows {
+		if row.TestedAt < start || row.TestedAt > nowTs {
+			continue
+		}
+		bucketStart := healthtrend.BucketStart(row.TestedAt)
+		if bucketStart <= 0 {
+			continue
+		}
+		agg := byBucket[bucketStart]
+		if agg == nil {
+			agg = &healthtrend.Aggregate{BucketStart: bucketStart}
+			byBucket[bucketStart] = agg
+		}
+		switch model.NormalizeChannelTestStatus(row.Status) {
+		case model.ChannelTestStatusSupported:
+			if row.Supported {
+				agg.SuccessCount++
+			} else {
+				agg.FailureCount++
+			}
+		case model.ChannelTestStatusSkipped:
+			// Encode skipped probes as mixed signal so the health strip shows
+			// a warning point without counting it as a hard unsupported result.
+			agg.SuccessCount++
+			agg.FailureCount++
+		default:
+			agg.FailureCount++
+		}
+		if row.LatencyMs > 0 {
+			agg.LatencyTotal += row.LatencyMs
+			agg.LatencyCount++
+		}
+	}
+	result := make([]healthtrend.Aggregate, 0, len(byBucket))
+	for _, agg := range byBucket {
+		if agg != nil {
+			result = append(result, *agg)
+		}
+	}
+	sort.Slice(result, func(i, j int) bool {
+		return result[i].BucketStart < result[j].BucketStart
+	})
+	return result
+}
+
 func buildUserModelStatusPayload(c *gin.Context) (UserModelStatusPayload, error) {
 	resolved, err := resolveRequestAvailableModels(c)
 	if err != nil {
@@ -825,6 +876,12 @@ func buildUserModelStatusPayload(c *gin.Context) (UserModelStatusPayload, error)
 					continue
 				}
 				modelTestRows = append(modelTestRows, row)
+			}
+		}
+		if trafficSummary.TotalCount == 0 {
+			testAggregates := buildUserModelStatusTestHealthAggregates(nowTs, modelTestRows)
+			if len(testAggregates) > 0 {
+				item.HealthPoints = healthtrend.BuildPoints(nowTs, testAggregates)
 			}
 		}
 		sort.SliceStable(modelTestRows, func(i, j int) bool {

--- a/internal/admin/controller/model_test.go
+++ b/internal/admin/controller/model_test.go
@@ -638,7 +638,7 @@ func TestBuildUserModelStatusPayloadAggregatesGroupModels(t *testing.T) {
 	recorder := httptest.NewRecorder()
 	c, _ := gin.CreateTestContext(recorder)
 	c.Set(ctxkey.AvailableModels, "gpt-5.4,claude-sonnet-4-6")
-	now := helper.GetTimestamp()
+	now := healthtrend.BucketStart(helper.GetTimestamp())
 
 	db, err := gorm.Open(sqlite.Open("file:"+t.Name()+"?mode=memory&cache=private"), &gorm.Config{})
 	if err != nil {
@@ -657,7 +657,7 @@ func TestBuildUserModelStatusPayloadAggregatesGroupModels(t *testing.T) {
 			Status:    model.ChannelTestStatusSupported,
 			Supported: true,
 			LatencyMs: 1200,
-			TestedAt:  now - 20,
+			TestedAt:  now,
 		},
 		{
 			ChannelId: "channel-2",
@@ -668,7 +668,7 @@ func TestBuildUserModelStatusPayloadAggregatesGroupModels(t *testing.T) {
 			Status:    model.ChannelTestStatusUnsupported,
 			Supported: false,
 			LatencyMs: 3000,
-			TestedAt:  now - 10,
+			TestedAt:  now,
 		},
 		{
 			ChannelId: "channel-3",
@@ -679,7 +679,7 @@ func TestBuildUserModelStatusPayloadAggregatesGroupModels(t *testing.T) {
 			Status:    model.ChannelTestStatusSkipped,
 			Supported: false,
 			LatencyMs: 0,
-			TestedAt:  now - 30,
+			TestedAt:  now,
 		},
 	}).Error; err != nil {
 		t.Fatalf("create channel tests: %v", err)
@@ -748,12 +748,30 @@ func TestBuildUserModelStatusPayloadAggregatesGroupModels(t *testing.T) {
 	if len(gpt.HealthPoints) != healthtrend.BucketCount {
 		t.Fatalf("gpt health points = %d, want %d", len(gpt.HealthPoints), healthtrend.BucketCount)
 	}
-	if gpt.HealthPoints[len(gpt.HealthPoints)-1].State != healthtrend.StateUnknown {
-		t.Fatalf("gpt latest point state = %q, want unknown without traffic", gpt.HealthPoints[len(gpt.HealthPoints)-1].State)
+	gptObserved := make([]healthtrend.Point, 0)
+	for _, point := range gpt.HealthPoints {
+		if point.TotalCount > 0 {
+			gptObserved = append(gptObserved, point)
+		}
+	}
+	if len(gptObserved) != 1 {
+		t.Fatalf("gpt observed points = %d, want 1 from channel tests", len(gptObserved))
+	}
+	if gptObserved[0].State != healthtrend.StateWarning || gptObserved[0].SuccessCount != 1 || gptObserved[0].FailureCount != 1 {
+		t.Fatalf("gpt test point = %+v, want warning with 1 success and 1 failure", gptObserved[0])
 	}
 	claude := byModel["claude-sonnet-4-6"]
 	if len(claude.HealthPoints) != healthtrend.BucketCount {
 		t.Fatalf("claude health points = %d, want %d", len(claude.HealthPoints), healthtrend.BucketCount)
+	}
+	claudeObserved := make([]healthtrend.Point, 0)
+	for _, point := range claude.HealthPoints {
+		if point.TotalCount > 0 {
+			claudeObserved = append(claudeObserved, point)
+		}
+	}
+	if len(claudeObserved) != 1 || claudeObserved[0].State != healthtrend.StateWarning {
+		t.Fatalf("claude observed point = %+v, want one warning point from skipped test", claudeObserved)
 	}
 	if len(claude.SupportedEndpoints) != 1 || claude.SupportedEndpoints[0] != model.ChannelModelEndpointMessages {
 		t.Fatalf("claude endpoints = %#v, want messages", claude.SupportedEndpoints)

--- a/web/src/locales/en/translation.json
+++ b/web/src/locales/en/translation.json
@@ -3583,12 +3583,12 @@
     "tooltip": {
       "success_count": "Successes",
       "failure_count": "Failures",
-      "total_count": "Calls",
+      "total_count": "Samples",
       "pass_rate": "Success Rate",
       "avg_latency": "Average Latency",
-      "no_sample": "No call sample in this time window",
+      "no_sample": "No call or health-check sample in this time window",
       "summary": {
-        "bucket": "Each cell summarizes real request successes, failures, and average latency within 5 minutes."
+        "bucket": "Each cell summarizes real request or health-check successes, failures, and average latency within 5 minutes."
       }
     },
     "card": {

--- a/web/src/locales/zh/translation.json
+++ b/web/src/locales/zh/translation.json
@@ -3578,12 +3578,12 @@
     "tooltip": {
       "success_count": "成功数",
       "failure_count": "失败数",
-      "total_count": "调用数",
+      "total_count": "样本数",
       "pass_rate": "成功率",
       "avg_latency": "平均延迟",
-      "no_sample": "该时间窗口暂无调用样本",
+      "no_sample": "该时间窗口暂无调用或健康检测样本",
       "summary": {
-        "bucket": "每个格子统计 5 分钟内真实请求的成功、失败和平均延迟。"
+        "bucket": "每个格子统计 5 分钟内真实请求或健康检测的成功、失败和平均延迟。"
       }
     },
     "card": {


### PR DESCRIPTION
## Summary
- fall back to recent health-check records when no real call samples exist
- keep the model health strip populated instead of showing empty windows
- update tooltip wording to reflect samples rather than calls only

## Validation
- go test ./...
- npm run build