### PR TITLE
Harden billing cost visibility and optional service integration

### DIFF
--- a/internal/admin/controller/billing/handler.go
+++ b/internal/admin/controller/billing/handler.go
@@ -134,6 +134,7 @@ func loadProcurementReportUnconfiguredModelChannels(summary model.ProcurementRep
 		model.ProcurementCostSourceActual,
 		model.ProcurementCostSourceEstimated,
 		model.ProcurementCostSourceZeroCost,
+		"pending",
 	}
 	query := model.LOG_DB.Table(model.EventLogsTableName).
 		Select(`
@@ -576,6 +577,8 @@ func GetProcurementReport(c *gin.Context) {
 		GroupBy:   c.Query("group_by"),
 		CostScope: c.Query("cost_scope"),
 		GroupID:   strings.TrimSpace(c.Query("group_id")),
+		ChannelID: strings.TrimSpace(c.Query("channel_id")),
+		Model:     strings.TrimSpace(c.Query("model")),
 	})
 	if err != nil {
 		c.JSON(http.StatusOK, gin.H{

--- a/internal/admin/controller/channel/billing_resource.go
+++ b/internal/admin/controller/channel/billing_resource.go
@@ -107,6 +107,17 @@ type channelBillingProfileUpdateRequest struct {
 }
 
 func GetChannelBillingAdapters(c *gin.Context) {
+	if !billingServiceConfigured() {
+		c.JSON(http.StatusOK, gin.H{
+			"success": true,
+			"message": "",
+			"data": channelBillingListData[billingServiceAdapterInfo]{
+				Items: []billingServiceAdapterInfo{},
+				Total: 0,
+			},
+		})
+		return
+	}
 	items, err := listBillingServiceAdapters(c.Request.Context())
 	if err != nil {
 		logChannelAdminWarn(c, "list_billing_adapters", stringField("reason", err.Error()))

--- a/internal/admin/controller/channel/billing_service_client_test.go
+++ b/internal/admin/controller/channel/billing_service_client_test.go
@@ -8,9 +8,40 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/gin-gonic/gin"
 	"github.com/yeying-community/router/common/config"
 	"github.com/yeying-community/router/internal/admin/model"
 )
+
+func TestGetChannelBillingAdaptersAllowsUnconfiguredOptionalService(t *testing.T) {
+	oldBaseURL := config.BillingServiceBaseURL
+	config.BillingServiceBaseURL = ""
+	t.Cleanup(func() { config.BillingServiceBaseURL = oldBaseURL })
+
+	gin.SetMode(gin.TestMode)
+	recorder := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(recorder)
+	c.Request = httptest.NewRequest(http.MethodGet, "/api/v1/admin/channel/billing/adapters", nil)
+
+	GetChannelBillingAdapters(c)
+
+	if recorder.Code != http.StatusOK {
+		t.Fatalf("status=%d, want %d", recorder.Code, http.StatusOK)
+	}
+	var response struct {
+		Success bool `json:"success"`
+		Data    struct {
+			Items []billingServiceAdapterInfo `json:"items"`
+			Total int                         `json:"total"`
+		} `json:"data"`
+	}
+	if err := json.Unmarshal(recorder.Body.Bytes(), &response); err != nil {
+		t.Fatalf("decode response: %v", err)
+	}
+	if !response.Success || len(response.Data.Items) != 0 || response.Data.Total != 0 {
+		t.Fatalf("unexpected response: %+v", response)
+	}
+}
 
 func configureBillingServiceForTest(t *testing.T, handler http.HandlerFunc, apiKey string) *httptest.Server {
 	t.Helper()

--- a/internal/admin/model/channel_model.go
+++ b/internal/admin/model/channel_model.go
@@ -640,6 +640,9 @@ func SetChannelModelPublishEnabledWithDB(db *gorm.DB, channelID string, modelNam
 			if duplicateCount > 0 {
 				return fmt.Errorf("发布名称 %s 已被该渠道其他模型使用，请先取消原模型发布", normalizedPublishedModel)
 			}
+			if err := ValidateChannelModelProcurementCostReadyWithDB(tx, row); err != nil {
+				return err
+			}
 		}
 		now := helper.GetTimestamp()
 		updates := map[string]any{

--- a/internal/admin/model/channel_model_test.go
+++ b/internal/admin/model/channel_model_test.go
@@ -483,6 +483,7 @@ func TestSetChannelModelPublishEnabledWithDBAllowsGPTImage2TokenBilling(t *testi
 		&ChannelModelEndpoint{},
 		&ChannelModelEndpointTestResult{},
 		&ChannelModelPriceComponent{},
+		&ChannelProcurementBatch{},
 	); err != nil {
 		t.Fatalf("auto migrate: %v", err)
 	}
@@ -527,6 +528,21 @@ func TestSetChannelModelPublishEnabledWithDBAllowsGPTImage2TokenBilling(t *testi
 		LastTestStatus: ChannelModelEndpointTestStatusSuccess,
 	}).Error; err != nil {
 		t.Fatalf("create endpoint test result: %v", err)
+	}
+	if err := db.Create(&ChannelProcurementBatch{
+		Id:                "batch-gpt-image-2",
+		ChannelId:         "channel-1",
+		ScopeType:         "model",
+		ScopeValue:        "gpt-image-2",
+		CapacityUnit:      "token",
+		CapacityTotal:     1000000,
+		CapacityEffective: 1000000,
+		CapacityRemaining: 1000000,
+		CostPerUnitAmount: 0.000001,
+		CostSource:        ProcurementCostSourceActual,
+		CostStatus:        ProcurementCostStatusActive,
+	}).Error; err != nil {
+		t.Fatalf("create procurement batch: %v", err)
 	}
 
 	if err := SetChannelModelPublishEnabledWithDB(db, "channel-1", "gpt-image-2", true, "gpt-image-2-public", "tester"); err != nil {

--- a/internal/admin/model/procurement.go
+++ b/internal/admin/model/procurement.go
@@ -112,6 +112,47 @@ type ProcurementEstimateResult struct {
 	MissingQuantity float64
 }
 
+// ValidateChannelModelProcurementCostReadyWithDB ensures a model has a
+// production-grade cost basis before it can be published. Estimated costs are
+// useful for planning, but only actual or explicitly zero-cost batches are
+// allowed to support production profitability reporting.
+func ValidateChannelModelProcurementCostReadyWithDB(db *gorm.DB, row ChannelModel) error {
+	if db == nil {
+		return fmt.Errorf("database handle is nil")
+	}
+	channelID := strings.TrimSpace(row.ChannelId)
+	modelName := strings.TrimSpace(row.Model)
+	if channelID == "" || modelName == "" {
+		return fmt.Errorf("渠道和模型不能为空")
+	}
+	pricing := resolvedPricingFromChannelModelRow(row)
+	capacityUnits := []string{normalizePricingCapacityUnit(pricing.PriceUnit)}
+	if currency := strings.TrimSpace(strings.ToLower(pricing.Currency)); currency != "" {
+		capacityUnits = append(capacityUnits, currency+"_equivalent")
+	}
+	capacityUnits = normalizeTrimmedValuesPreserveOrder(capacityUnits)
+	now := helper.GetTimestamp()
+	count := int64(0)
+	err := db.Model(&ChannelProcurementBatch{}).
+		Where("channel_id = ?", channelID).
+		Where("capacity_unit IN ?", capacityUnits).
+		Where("cost_status = ?", ProcurementCostStatusActive).
+		Where("cost_source IN ?", []string{ProcurementCostSourceActual, ProcurementCostSourceZeroCost}).
+		Where("capacity_remaining > 0").
+		Where("(valid_from = 0 OR valid_from <= ?)", now).
+		Where("(expire_at = 0 OR expire_at > ?)", now).
+		Where("(scope_type = ? OR (scope_type = ? AND scope_value = ?))", "global", "model", modelName).
+		Where("cost_source = ? OR cost_per_unit_amount > 0", ProcurementCostSourceZeroCost).
+		Count(&count).Error
+	if err != nil {
+		return err
+	}
+	if count <= 0 {
+		return fmt.Errorf("模型 %s 缺少正式采购成本：请配置有效的实际成本或明确零成本采购批次，且容量单位必须匹配 %s", modelName, strings.Join(capacityUnits, " / "))
+	}
+	return nil
+}
+
 type ProcurementBatchCostUpdate struct {
 	PurchaseCurrency   string
 	PurchaseAmount     float64

--- a/internal/admin/model/procurement_cost_readiness_test.go
+++ b/internal/admin/model/procurement_cost_readiness_test.go
@@ -1,0 +1,96 @@
+package model
+
+import (
+	"strings"
+	"testing"
+
+	"gorm.io/driver/sqlite"
+	"gorm.io/gorm"
+)
+
+func newProcurementCostReadinessTestDB(t *testing.T) *gorm.DB {
+	t.Helper()
+	db, err := gorm.Open(sqlite.Open("file:"+t.Name()+"?mode=memory&cache=private"), &gorm.Config{})
+	if err != nil {
+		t.Fatalf("open sqlite: %v", err)
+	}
+	if err := db.AutoMigrate(&ChannelProcurementBatch{}); err != nil {
+		t.Fatalf("AutoMigrate: %v", err)
+	}
+	return db
+}
+
+func TestValidateChannelModelProcurementCostReadyAcceptsActualAndZeroCost(t *testing.T) {
+	for _, source := range []string{ProcurementCostSourceActual, ProcurementCostSourceZeroCost} {
+		t.Run(source, func(t *testing.T) {
+			db := newProcurementCostReadinessTestDB(t)
+			unitCost := 0.0
+			if source == ProcurementCostSourceActual {
+				unitCost = 0.001
+			}
+			if err := db.Create(&ChannelProcurementBatch{
+				Id:                "batch-" + source,
+				ChannelId:         "channel-1",
+				ScopeType:         "model",
+				ScopeValue:        "model-1",
+				CapacityUnit:      "token",
+				CapacityTotal:     1000,
+				CapacityEffective: 1000,
+				CapacityRemaining: 1000,
+				CostPerUnitAmount: unitCost,
+				CostSource:        source,
+				CostStatus:        ProcurementCostStatusActive,
+			}).Error; err != nil {
+				t.Fatalf("create batch: %v", err)
+			}
+			err := ValidateChannelModelProcurementCostReadyWithDB(db, ChannelModel{
+				ChannelId: "channel-1",
+				Model:     "model-1",
+				PriceUnit: ProviderPriceUnitPer1KTokens,
+				Currency:  ProviderPriceCurrencyUSD,
+			})
+			if err != nil {
+				t.Fatalf("ValidateChannelModelProcurementCostReadyWithDB: %v", err)
+			}
+		})
+	}
+}
+
+func TestValidateChannelModelProcurementCostReadyRejectsEstimatedAndUnitMismatch(t *testing.T) {
+	for _, testCase := range []struct {
+		name       string
+		source     string
+		unit       string
+		wantReason string
+	}{
+		{name: "estimated", source: ProcurementCostSourceEstimated, unit: "token", wantReason: "缺少正式采购成本"},
+		{name: "unit mismatch", source: ProcurementCostSourceActual, unit: "request", wantReason: "容量单位必须匹配"},
+	} {
+		t.Run(testCase.name, func(t *testing.T) {
+			db := newProcurementCostReadinessTestDB(t)
+			if err := db.Create(&ChannelProcurementBatch{
+				Id:                "batch-1",
+				ChannelId:         "channel-1",
+				ScopeType:         "global",
+				CapacityUnit:      testCase.unit,
+				CapacityTotal:     1000,
+				CapacityEffective: 1000,
+				CapacityRemaining: 1000,
+				CostPerUnitAmount: 0.001,
+				CostSource:        testCase.source,
+				CostStatus:        ProcurementCostStatusActive,
+			}).Error; err != nil {
+				t.Fatalf("create batch: %v", err)
+			}
+			err := ValidateChannelModelProcurementCostReadyWithDB(db, ChannelModel{
+				ChannelId: "channel-1",
+				Model:     "model-1",
+				PriceUnit: ProviderPriceUnitPer1KTokens,
+				Currency:  ProviderPriceCurrencyUSD,
+			})
+			if err == nil || !strings.Contains(err.Error(), testCase.wantReason) {
+				t.Fatalf("error=%v, want reason %q", err, testCase.wantReason)
+			}
+		})
+	}
+}

--- a/internal/admin/model/procurement_report.go
+++ b/internal/admin/model/procurement_report.go
@@ -24,6 +24,8 @@ type ProcurementReportQuery struct {
 	GroupBy   string
 	CostScope string
 	GroupID   string
+	ChannelID string
+	Model     string
 }
 
 type ProcurementReportItem struct {
@@ -34,6 +36,10 @@ type ProcurementReportItem struct {
 	UnconfiguredCostRequestCount int64   `json:"unconfigured_cost_request_count" gorm:"column:unconfigured_cost_request_count"`
 	EstimatedCostRequestCount    int64   `json:"estimated_cost_request_count" gorm:"column:estimated_cost_request_count"`
 	PendingCostRequestCount      int64   `json:"pending_cost_request_count" gorm:"column:pending_cost_request_count"`
+	InputQuantity                float64 `json:"input_quantity" gorm:"column:input_quantity"`
+	OutputQuantity               float64 `json:"output_quantity" gorm:"column:output_quantity"`
+	CacheReadQuantity            float64 `json:"cache_read_quantity" gorm:"column:cache_read_quantity"`
+	CacheWriteQuantity           float64 `json:"cache_write_quantity" gorm:"column:cache_write_quantity"`
 	RouterConsumedYYC            int64   `json:"router_consumed_yyc" gorm:"column:router_consumed_yyc"`
 	SellBaseAmount               float64 `json:"sell_base_amount" gorm:"column:sell_base_amount"`
 	ConfiguredSellBaseAmount     float64 `json:"configured_sell_base_amount" gorm:"column:configured_sell_base_amount"`
@@ -62,6 +68,10 @@ type ProcurementReportSummary struct {
 	UnconfiguredCostRequestCount int64                   `json:"unconfigured_cost_request_count"`
 	EstimatedCostRequestCount    int64                   `json:"estimated_cost_request_count"`
 	PendingCostRequestCount      int64                   `json:"pending_cost_request_count"`
+	InputQuantity                float64                 `json:"input_quantity"`
+	OutputQuantity               float64                 `json:"output_quantity"`
+	CacheReadQuantity            float64                 `json:"cache_read_quantity"`
+	CacheWriteQuantity           float64                 `json:"cache_write_quantity"`
 	RouterConsumedYYC            int64                   `json:"router_consumed_yyc"`
 	SellBaseAmount               float64                 `json:"sell_base_amount"`
 	ConfiguredSellBaseAmount     float64                 `json:"configured_sell_base_amount"`
@@ -74,10 +84,20 @@ type ProcurementReportSummary struct {
 }
 
 type ProcurementTrendItem struct {
-	Day                      string  `json:"day" gorm:"column:day"`
-	RequestCount             int64   `json:"request_count" gorm:"column:request_count"`
-	CostFloorTriggeredCount  int64   `json:"cost_floor_triggered_count" gorm:"column:cost_floor_triggered_count"`
-	CostFloorTriggeredAmount float64 `json:"cost_floor_triggered_amount" gorm:"column:cost_floor_triggered_amount"`
+	Day                          string  `json:"day" gorm:"column:day"`
+	RequestCount                 int64   `json:"request_count" gorm:"column:request_count"`
+	ConfiguredCostRequestCount   int64   `json:"configured_cost_request_count" gorm:"column:configured_cost_request_count"`
+	UnconfiguredCostRequestCount int64   `json:"unconfigured_cost_request_count" gorm:"column:unconfigured_cost_request_count"`
+	InputQuantity                float64 `json:"input_quantity" gorm:"column:input_quantity"`
+	OutputQuantity               float64 `json:"output_quantity" gorm:"column:output_quantity"`
+	CacheReadQuantity            float64 `json:"cache_read_quantity" gorm:"column:cache_read_quantity"`
+	CacheWriteQuantity           float64 `json:"cache_write_quantity" gorm:"column:cache_write_quantity"`
+	RouterConsumedYYC            int64   `json:"router_consumed_yyc" gorm:"column:router_consumed_yyc"`
+	SellBaseAmount               float64 `json:"sell_base_amount" gorm:"column:sell_base_amount"`
+	ProcurementCostBaseAmount    float64 `json:"procurement_cost_base_amount" gorm:"column:procurement_cost_base_amount"`
+	GrossProfitBaseAmount        float64 `json:"gross_profit_base_amount" gorm:"column:gross_profit_base_amount"`
+	CostFloorTriggeredCount      int64   `json:"cost_floor_triggered_count" gorm:"column:cost_floor_triggered_count"`
+	CostFloorTriggeredAmount     float64 `json:"cost_floor_triggered_amount" gorm:"column:cost_floor_triggered_amount"`
 }
 
 type ProcurementTrendQuery struct {
@@ -93,12 +113,24 @@ func ListProcurementTrendWithDB(db *gorm.DB, query ProcurementTrendQuery) ([]Pro
 		return nil, fmt.Errorf("database handle is nil")
 	}
 	rows := make([]ProcurementTrendItem, 0)
+	configuredSources := []string{ProcurementCostSourceActual, ProcurementCostSourceZeroCost}
+	knownSources := []string{ProcurementCostSourceActual, ProcurementCostSourceEstimated, ProcurementCostSourceZeroCost, "pending"}
 	dbQuery := db.Table(EventLogsTableName).Select(`
 		TO_CHAR(TO_TIMESTAMP(created_at), 'YYYY-MM-DD') AS day,
 		COUNT(1) AS request_count,
+		COALESCE(SUM(CASE WHEN billing_procurement_cost_source IN ? THEN 1 ELSE 0 END), 0) AS configured_cost_request_count,
+		COALESCE(SUM(CASE WHEN billing_procurement_cost_source NOT IN ? OR COALESCE(NULLIF(TRIM(billing_procurement_cost_source), ''), '') = '' THEN 1 ELSE 0 END), 0) AS unconfigured_cost_request_count,
+		COALESCE(SUM(billing_input_quantity), 0) AS input_quantity,
+		COALESCE(SUM(billing_output_quantity), 0) AS output_quantity,
+		COALESCE(SUM(billing_cache_read_quantity), 0) AS cache_read_quantity,
+		COALESCE(SUM(billing_cache_write_quantity), 0) AS cache_write_quantity,
+		COALESCE(SUM(billing_charge_amount), 0) AS router_consumed_yyc,
+		COALESCE(SUM(billing_sell_base_amount), 0) AS sell_base_amount,
+		COALESCE(SUM(CASE WHEN billing_procurement_cost_source IN ? THEN billing_procurement_cost_base_amount ELSE 0 END), 0) AS procurement_cost_base_amount,
+		COALESCE(SUM(CASE WHEN billing_procurement_cost_source IN ? THEN billing_gross_profit_base_amount ELSE 0 END), 0) AS gross_profit_base_amount,
 		COALESCE(SUM(CASE WHEN billing_cost_floor_triggered = TRUE THEN 1 ELSE 0 END), 0) AS cost_floor_triggered_count,
 		COALESCE(SUM(CASE WHEN billing_cost_floor_triggered = TRUE THEN billing_cost_floor_base_amount ELSE 0 END), 0) AS cost_floor_triggered_amount
-	`).Where("type = ? AND created_at BETWEEN ? AND ?", LogTypeConsume, query.StartAt, query.EndAt)
+	`, configuredSources, knownSources, configuredSources, configuredSources).Where("type = ? AND created_at BETWEEN ? AND ?", LogTypeConsume, query.StartAt, query.EndAt)
 	if strings.TrimSpace(query.GroupID) != "" {
 		dbQuery = dbQuery.Where("group_id = ?", strings.TrimSpace(query.GroupID))
 	}
@@ -106,7 +138,7 @@ func ListProcurementTrendWithDB(db *gorm.DB, query ProcurementTrendQuery) ([]Pro
 		dbQuery = dbQuery.Where("channel_id = ?", strings.TrimSpace(query.ChannelID))
 	}
 	if strings.TrimSpace(query.Model) != "" {
-		dbQuery = dbQuery.Where("model_name = ?", strings.TrimSpace(query.Model))
+		dbQuery = dbQuery.Where("COALESCE(NULLIF(TRIM(actual_model_name), ''), NULLIF(TRIM(model_name), '')) = ?", strings.TrimSpace(query.Model))
 	}
 	err := dbQuery.Group("day").Order("day ASC").Scan(&rows).Error
 	return rows, err
@@ -137,7 +169,7 @@ func NormalizeProcurementReportGroupBy(value string) string {
 func procurementReportDimensionExpression(groupBy string) string {
 	switch NormalizeProcurementReportGroupBy(groupBy) {
 	case ProcurementReportGroupByModel:
-		return "COALESCE(NULLIF(TRIM(model_name), ''), '-')"
+		return "COALESCE(NULLIF(TRIM(actual_model_name), ''), NULLIF(TRIM(model_name), ''), '-')"
 	case ProcurementReportGroupByEndpoint:
 		return "COALESCE(NULLIF(TRIM(upstream_endpoint), ''), '-')"
 	default:
@@ -170,6 +202,7 @@ func ListProcurementReportWithDB(db *gorm.DB, query ProcurementReportQuery) (Pro
 	dimensionExpr := procurementReportDimensionExpression(groupBy)
 	rows := make([]ProcurementReportItem, 0)
 	configuredSources := []string{ProcurementCostSourceActual, ProcurementCostSourceZeroCost}
+	knownSources := []string{ProcurementCostSourceActual, ProcurementCostSourceEstimated, ProcurementCostSourceZeroCost, "pending"}
 	queryDB := db.Table(EventLogsTableName).
 		Select(`
 			`+dimensionExpr+` AS dimension_key,
@@ -178,6 +211,10 @@ func ListProcurementReportWithDB(db *gorm.DB, query ProcurementReportQuery) (Pro
 			COALESCE(SUM(CASE WHEN billing_procurement_cost_source NOT IN ? OR COALESCE(NULLIF(TRIM(billing_procurement_cost_source), ''), '') = '' THEN 1 ELSE 0 END), 0) AS unconfigured_cost_request_count,
 			COALESCE(SUM(CASE WHEN billing_procurement_cost_source = ? THEN 1 ELSE 0 END), 0) AS estimated_cost_request_count,
 			COALESCE(SUM(CASE WHEN billing_procurement_cost_source = ? THEN 1 ELSE 0 END), 0) AS pending_cost_request_count,
+			COALESCE(SUM(billing_input_quantity), 0) AS input_quantity,
+			COALESCE(SUM(billing_output_quantity), 0) AS output_quantity,
+			COALESCE(SUM(billing_cache_read_quantity), 0) AS cache_read_quantity,
+			COALESCE(SUM(billing_cache_write_quantity), 0) AS cache_write_quantity,
 			COALESCE(SUM(billing_charge_amount), 0) AS router_consumed_yyc,
 			COALESCE(SUM(billing_sell_base_amount), 0) AS sell_base_amount,
 			COALESCE(SUM(CASE WHEN billing_procurement_cost_source IN ? THEN billing_sell_base_amount ELSE 0 END), 0) AS configured_sell_base_amount,
@@ -191,13 +228,19 @@ func ListProcurementReportWithDB(db *gorm.DB, query ProcurementReportQuery) (Pro
 			COALESCE(SUM(CASE WHEN billing_procurement_cost_source = ? THEN 1 ELSE 0 END), 0) AS zero_cost_request_count,
 			COALESCE(MIN(created_at), 0) AS first_request_at,
 			COALESCE(MAX(created_at), 0) AS last_request_at
-		`, configuredSources, configuredSources, ProcurementCostSourceEstimated, "pending", configuredSources, configuredSources, configuredSources, configuredSources, ProcurementCostSourceActual, ProcurementCostSourceEstimated, ProcurementCostSourceZeroCost).
+		`, configuredSources, knownSources, ProcurementCostSourceEstimated, "pending", configuredSources, knownSources, configuredSources, configuredSources, ProcurementCostSourceActual, ProcurementCostSourceEstimated, ProcurementCostSourceZeroCost).
 		Where("type = ? AND created_at BETWEEN ? AND ?", LogTypeConsume, query.StartAt, query.EndAt)
 	if summary.GroupID != "" {
 		queryDB = queryDB.Where("group_id = ?", summary.GroupID)
 	}
+	if strings.TrimSpace(query.ChannelID) != "" {
+		queryDB = queryDB.Where("channel_id = ?", strings.TrimSpace(query.ChannelID))
+	}
+	if strings.TrimSpace(query.Model) != "" {
+		queryDB = queryDB.Where("COALESCE(NULLIF(TRIM(actual_model_name), ''), NULLIF(TRIM(model_name), '')) = ?", strings.TrimSpace(query.Model))
+	}
 	if costScope == ProcurementReportCostScopeUnconfigured {
-		queryDB = queryDB.Where(procurementReportUnconfiguredCostCondition(), configuredSources)
+		queryDB = queryDB.Where(procurementReportUnconfiguredCostCondition(), knownSources)
 	}
 	if err := queryDB.
 		Group("dimension_key").
@@ -215,6 +258,10 @@ func ListProcurementReportWithDB(db *gorm.DB, query ProcurementReportQuery) (Pro
 		summary.UnconfiguredCostRequestCount += rows[index].UnconfiguredCostRequestCount
 		summary.EstimatedCostRequestCount += rows[index].EstimatedCostRequestCount
 		summary.PendingCostRequestCount += rows[index].PendingCostRequestCount
+		summary.InputQuantity += rows[index].InputQuantity
+		summary.OutputQuantity += rows[index].OutputQuantity
+		summary.CacheReadQuantity += rows[index].CacheReadQuantity
+		summary.CacheWriteQuantity += rows[index].CacheWriteQuantity
 		summary.RouterConsumedYYC += rows[index].RouterConsumedYYC
 		summary.SellBaseAmount += rows[index].SellBaseAmount
 		summary.ConfiguredSellBaseAmount += rows[index].ConfiguredSellBaseAmount

--- a/internal/admin/model/procurement_test.go
+++ b/internal/admin/model/procurement_test.go
@@ -934,6 +934,11 @@ func TestListProcurementReportWithDB(t *testing.T) {
 			ChannelId:                        "channel-1",
 			UpstreamEndpoint:                 "/v1/chat/completions",
 			ModelName:                        "gpt-5",
+			ActualModelName:                  "gpt-5-routed",
+			BillingInputQuantity:             1000,
+			BillingOutputQuantity:            200,
+			BillingCacheReadQuantity:         300,
+			BillingCacheWriteQuantity:        40,
 			BillingChargeAmount:              100,
 			BillingSellBaseAmount:            10,
 			BillingProcurementCostBaseAmount: 4,
@@ -947,6 +952,9 @@ func TestListProcurementReportWithDB(t *testing.T) {
 			ChannelId:                    "channel-1",
 			UpstreamEndpoint:             "/v1/chat/completions",
 			ModelName:                    "gpt-5",
+			ActualModelName:              "gpt-5-routed",
+			BillingInputQuantity:         500,
+			BillingOutputQuantity:        100,
 			BillingChargeAmount:          80,
 			BillingSellBaseAmount:        8,
 			BillingProcurementCostSource: ProcurementCostSourceNone,
@@ -1006,6 +1014,23 @@ func TestListProcurementReportWithDB(t *testing.T) {
 	if report.RouterConsumedYYC != 230 {
 		t.Fatalf("RouterConsumedYYC=%d, want 230", report.RouterConsumedYYC)
 	}
+	if report.InputQuantity != 1500 || report.OutputQuantity != 300 || report.CacheReadQuantity != 300 || report.CacheWriteQuantity != 40 {
+		t.Fatalf("unexpected token quantities: input=%v output=%v cache_read=%v cache_write=%v", report.InputQuantity, report.OutputQuantity, report.CacheReadQuantity, report.CacheWriteQuantity)
+	}
+
+	filteredReport, err := ListProcurementReportWithDB(db, ProcurementReportQuery{
+		StartAt:   90,
+		EndAt:     140,
+		GroupBy:   ProcurementReportGroupByModel,
+		ChannelID: "channel-1",
+		Model:     "gpt-5-routed",
+	})
+	if err != nil {
+		t.Fatalf("list filtered report: %v", err)
+	}
+	if filteredReport.RequestCount != 2 || len(filteredReport.Items) != 1 || filteredReport.Items[0].DimensionKey != "gpt-5-routed" {
+		t.Fatalf("unexpected filtered report: requests=%d items=%+v", filteredReport.RequestCount, filteredReport.Items)
+	}
 
 	endpointReport, err := ListProcurementReportWithDB(db, ProcurementReportQuery{
 		StartAt: 90,
@@ -1042,5 +1067,45 @@ func TestListProcurementReportWithDB(t *testing.T) {
 	}
 	if unconfiguredReport.GrossProfitBaseAmount != 0 {
 		t.Fatalf("unconfigured GrossProfitBaseAmount=%v, want 0", unconfiguredReport.GrossProfitBaseAmount)
+	}
+}
+
+func TestListProcurementReportDoesNotClassifyEstimatedCostAsUnconfigured(t *testing.T) {
+	db := newProcurementTestDB(t)
+	if err := db.Create(&Log{
+		Id:                               "log-estimated",
+		Type:                             LogTypeConsume,
+		CreatedAt:                        100,
+		ChannelId:                        "channel-1",
+		ModelName:                        "model-1",
+		BillingSellBaseAmount:            10,
+		BillingProcurementCostBaseAmount: 4,
+		BillingProcurementCostSource:     ProcurementCostSourceEstimated,
+		BillingGrossProfitBaseAmount:     6,
+	}).Error; err != nil {
+		t.Fatalf("seed estimated log: %v", err)
+	}
+	report, err := ListProcurementReportWithDB(db, ProcurementReportQuery{
+		StartAt: 90,
+		EndAt:   110,
+		GroupBy: ProcurementReportGroupByChannel,
+	})
+	if err != nil {
+		t.Fatalf("list report: %v", err)
+	}
+	if report.RequestCount != 1 || report.EstimatedCostRequestCount != 1 || report.UnconfiguredCostRequestCount != 0 {
+		t.Fatalf("unexpected counts: requests=%d estimated=%d unconfigured=%d", report.RequestCount, report.EstimatedCostRequestCount, report.UnconfiguredCostRequestCount)
+	}
+	unconfigured, err := ListProcurementReportWithDB(db, ProcurementReportQuery{
+		StartAt:   90,
+		EndAt:     110,
+		GroupBy:   ProcurementReportGroupByChannel,
+		CostScope: ProcurementReportCostScopeUnconfigured,
+	})
+	if err != nil {
+		t.Fatalf("list unconfigured report: %v", err)
+	}
+	if unconfigured.RequestCount != 0 {
+		t.Fatalf("unconfigured RequestCount=%d, want 0", unconfigured.RequestCount)
 	}
 }

--- a/web/src/locales/en/translation.json
+++ b/web/src/locales/en/translation.json
@@ -3453,10 +3453,12 @@
       "structure": { "title": "Billing structure", "summary": "Overview shows revenue and cost results. Model Pricing checks price coverage. Channel Procurement tracks upstream batches and cost attribution.", "pricing": "View model pricing", "procurement": "View channel procurement" },
       "load_failed": "Failed to load business data",
       "metrics": { "revenue": "Revenue CNY", "cost": "Procurement Cost CNY", "profit": "Gross Profit CNY", "margin": "Gross Margin", "yyc": "Router YYC Consumed", "requests": "Requests", "floor_triggered": "Floor triggers", "floor_amount": "Floor impact CNY" },
+      "tokens": { "title": "Token consumption", "input": "Input tokens", "output": "Output tokens", "cache_read": "Cache-read tokens", "cache_write": "Cache-write tokens" },
       "confidence": { "title": "Cost data confidence", "coverage": "Actual cost coverage {{value}}", "detail": "Estimated {{estimated}}, pending {{pending}}, unconfigured {{unconfigured}}" },
-      "risks": { "title": "Risks to handle", "view_details": "View details", "empty": "No pending risks" },
+      "operating_risks": { "title": "Operating exceptions in scope", "view_details": "View model pricing", "empty": "No operating exception in the current scope", "unconfigured": "{{model}} has {{count}} requests without cost", "loss": "{{model}} has formal profit of {{amount}}", "low_margin": "{{model}} has only {{margin}} formal margin", "floor": "{{model}} triggered the cost floor {{count}} times", "estimated": "{{model}} has {{count}} requests using estimated cost only", "pending": "{{model}} has {{count}} requests pending cost attribution" },
+      "configuration_risks": { "title": "Global billing configuration risks", "view_details": "View channel procurement", "empty": "No global billing configuration risk" },
       "channels": { "title": "Channel floor impact", "view_details": "View reconciliation", "empty": "No channel data" },
-      "trend": { "title": "7-day floor trend" },
+      "trend": { "title": "7-day consumption and margin trend", "tokens": "Input {{input}} / Output {{output}}", "financials": "Revenue {{revenue}} / Cost {{cost}} / Profit {{profit}}", "coverage": "Formal cost {{configured}} / {{total}}" },
       "channel_placeholder": "Filter channel", "model_placeholder": "Filter model"
     },
     "procurement_report": {

--- a/web/src/locales/zh/translation.json
+++ b/web/src/locales/zh/translation.json
@@ -3448,10 +3448,12 @@
       "structure": { "title": "计费结构", "summary": "总览看收入与成本结果；模型定价看售价是否覆盖成本；渠道采购看上游采购批次与成本归因。", "pricing": "查看模型定价", "procurement": "查看渠道采购" },
       "load_failed": "经营数据加载失败",
       "metrics": { "revenue": "收入 CNY", "cost": "采购成本 CNY", "profit": "毛利 CNY", "margin": "毛利率", "yyc": "Router 消耗 YYC", "requests": "请求数", "floor_triggered": "底线触发次数", "floor_amount": "底线影响 CNY" },
+      "tokens": { "title": "Token 消耗结构", "input": "输入 Token", "output": "输出 Token", "cache_read": "缓存读取 Token", "cache_write": "缓存写入 Token" },
       "confidence": { "title": "成本数据可信度", "coverage": "真实成本覆盖 {{value}}", "detail": "估算 {{estimated}}，待归因 {{pending}}，未配置 {{unconfigured}}" },
-      "risks": { "title": "待处理风险", "view_details": "查看明细", "empty": "暂未发现待处理风险" },
+      "operating_risks": { "title": "当前范围经营异常", "view_details": "查看模型定价", "empty": "当前范围未发现经营异常", "unconfigured": "{{model}} 有 {{count}} 个请求未配置成本", "loss": "{{model}} 正式毛利为 {{amount}}", "low_margin": "{{model}} 正式毛利率仅 {{margin}}", "floor": "{{model}} 触发成本底线 {{count}} 次", "estimated": "{{model}} 有 {{count}} 个请求仅使用估算成本", "pending": "{{model}} 有 {{count}} 个请求成本待归因" },
+      "configuration_risks": { "title": "全局计费配置风险", "view_details": "查看渠道采购", "empty": "未发现全局计费配置风险" },
       "channels": { "title": "渠道底线影响", "view_details": "查看渠道对账", "empty": "暂无渠道数据" },
-      "trend": { "title": "近 7 天底线趋势" },
+      "trend": { "title": "近 7 天消耗与毛利趋势", "tokens": "输入 {{input}} / 输出 {{output}}", "financials": "收入 {{revenue}} / 成本 {{cost}} / 毛利 {{profit}}", "coverage": "正式成本 {{configured}} / {{total}}" },
       "channel_placeholder": "筛选渠道", "model_placeholder": "筛选模型"
     },
     "procurement_report": {

--- a/web/src/locales/zh/translation.json
+++ b/web/src/locales/zh/translation.json
@@ -3444,7 +3444,7 @@
     },
     "overview": {
       "nav": "经营总览",
-      "title": "计费经营总览",
+      "title": "经营总览",
       "structure": { "title": "计费结构", "summary": "总览看收入与成本结果；模型定价看售价是否覆盖成本；渠道采购看上游采购批次与成本归因。", "pricing": "查看模型定价", "procurement": "查看渠道采购" },
       "load_failed": "经营数据加载失败",
       "metrics": { "revenue": "收入 CNY", "cost": "采购成本 CNY", "profit": "毛利 CNY", "margin": "毛利率", "yyc": "Router 消耗 YYC", "requests": "请求数", "floor_triggered": "底线触发次数", "floor_amount": "底线影响 CNY" },

--- a/web/src/pages/BillingOverview/BillingOverview.css
+++ b/web/src/pages/BillingOverview/BillingOverview.css
@@ -7,6 +7,10 @@
 .billing-overview-metric { min-height: 92px; padding: 14px; border: 1px solid rgba(15, 23, 42, .08); border-radius: 10px; background: #fff; }
 .billing-overview-label { color: #64748b; font-size: 12px; }
 .billing-overview-value { margin-top: 10px; color: #0f172a; font-size: 22px; font-weight: 700; }
+.billing-overview-token-heading { margin-top: 18px; }
+.billing-overview-token-grid { display: grid; grid-template-columns: repeat(4, minmax(0, 1fr)); gap: 10px; }
+.billing-overview-token { display: flex; align-items: baseline; justify-content: space-between; gap: 12px; padding: 12px 14px; border: 1px solid rgba(15, 23, 42, .08); border-radius: 8px; color: #64748b; font-size: 12px; }
+.billing-overview-token strong { color: #0f172a; font-size: 16px; }
 .billing-overview-confidence { margin-top: 12px; padding: 12px 14px; border: 1px solid rgba(245, 158, 11, .3); border-radius: 10px; background: #fffbeb; }
 .billing-overview-confidence.is-good { border-color: rgba(22, 163, 74, .25); background: #f0fdf4; }
 .billing-overview-confidence > div:first-child { display: flex; gap: 10px; color: #334155; font-size: 13px; }
@@ -14,12 +18,15 @@
 .billing-overview-confidence-bar span { display: block; height: 100%; background: #16a34a; }
 .billing-overview-confidence-detail { margin-top: 8px; color: #64748b; font-size: 12px; }
 .billing-overview-columns { display: grid; grid-template-columns: repeat(2, minmax(0, 1fr)); gap: 12px; margin-top: 12px; }
+.billing-overview-global-risks { margin-top: 12px; }
 .billing-overview-section-heading { display: flex; align-items: center; justify-content: space-between; gap: 12px; margin-bottom: 12px; }
 .billing-overview-section-heading h2 { margin: 0; font-size: 16px; }
 .billing-overview-section-heading a { color: #2563eb; font-size: 13px; }
 .billing-overview-risk, .billing-overview-channel { display: flex; align-items: center; justify-content: space-between; gap: 10px; min-height: 38px; border-bottom: 1px solid rgba(15, 23, 42, .06); color: #334155; font-size: 13px; }
 .billing-overview-risk span { overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
 .billing-overview-channel strong { color: #0f172a; }
+.billing-overview-trend-row { display: grid; grid-template-columns: 100px minmax(180px, 1fr) minmax(280px, 2fr) minmax(120px, auto); align-items: center; gap: 12px; min-height: 42px; border-bottom: 1px solid rgba(15, 23, 42, .06); color: #475569; font-size: 12px; }
+.billing-overview-trend-row strong { color: #0f172a; text-align: right; }
 .billing-overview-empty { padding: 24px 0; color: #64748b; text-align: center; }
-@media (max-width: 900px) { .billing-overview-metric-grid { grid-template-columns: repeat(3, minmax(0, 1fr)); } .billing-overview-columns { grid-template-columns: 1fr; } }
-@media (max-width: 560px) { .billing-overview-metric-grid { grid-template-columns: repeat(2, minmax(0, 1fr)); } }
+@media (max-width: 900px) { .billing-overview-metric-grid { grid-template-columns: repeat(3, minmax(0, 1fr)); } .billing-overview-token-grid { grid-template-columns: repeat(2, minmax(0, 1fr)); } .billing-overview-columns { grid-template-columns: 1fr; } .billing-overview-trend-row { grid-template-columns: 90px 1fr; } .billing-overview-trend-row strong { text-align: left; } }
+@media (max-width: 560px) { .billing-overview-metric-grid, .billing-overview-token-grid { grid-template-columns: repeat(2, minmax(0, 1fr)); } }

--- a/web/src/pages/BillingOverview/BillingOverview.css
+++ b/web/src/pages/BillingOverview/BillingOverview.css
@@ -1,4 +1,6 @@
 .billing-overview-page { max-width: 1600px; }
+.billing-overview-channel-select { width: 260px; }
+.billing-overview-model-select { width: 300px; }
 .billing-overview-map { display: flex; align-items: center; flex-wrap: wrap; gap: 8px 16px; margin: 12px 0; padding: 12px 14px; border-left: 3px solid #2563eb; background: #f8fafc; color: #475569; font-size: 13px; }
 .billing-overview-map strong { color: #0f172a; }
 .billing-overview-map a { color: #2563eb; }
@@ -29,4 +31,4 @@
 .billing-overview-trend-row strong { color: #0f172a; text-align: right; }
 .billing-overview-empty { padding: 24px 0; color: #64748b; text-align: center; }
 @media (max-width: 900px) { .billing-overview-metric-grid { grid-template-columns: repeat(3, minmax(0, 1fr)); } .billing-overview-token-grid { grid-template-columns: repeat(2, minmax(0, 1fr)); } .billing-overview-columns { grid-template-columns: 1fr; } .billing-overview-trend-row { grid-template-columns: 90px 1fr; } .billing-overview-trend-row strong { text-align: left; } }
-@media (max-width: 560px) { .billing-overview-metric-grid, .billing-overview-token-grid { grid-template-columns: repeat(2, minmax(0, 1fr)); } }
+@media (max-width: 560px) { .billing-overview-channel-select, .billing-overview-model-select { width: min(100%, 300px); } .billing-overview-metric-grid, .billing-overview-token-grid { grid-template-columns: repeat(2, minmax(0, 1fr)); } }

--- a/web/src/pages/BillingOverview/index.jsx
+++ b/web/src/pages/BillingOverview/index.jsx
@@ -107,7 +107,7 @@ function BillingOverview() {
         setModelOptions((Array.isArray(modelOptionsResponse.data?.data?.items) ? modelOptionsResponse.data.data.items : []).map((item) => ({ key: item.dimension_key, value: item.dimension_key, text: item.dimension_key })));
       }
       if (channelOptionsResponse.data?.success) {
-        setChannelOptions((Array.isArray(channelOptionsResponse.data?.data?.items) ? channelOptionsResponse.data.data.items : []).map((item) => ({ key: item.dimension_key, value: item.dimension_key, text: item.dimension_key })));
+        setChannelOptions((Array.isArray(channelOptionsResponse.data?.data?.items) ? channelOptionsResponse.data.data.items : []).map((item) => ({ key: item.dimension_key, value: item.dimension_key, text: item.dimension_name || item.dimension_key })));
       }
       if (healthResponse.data?.success) {
         setHealth(healthResponse.data.data || {});
@@ -150,7 +150,7 @@ function BillingOverview() {
     <div className='dashboard-container billing-overview-page'>
       <AppFilterHeader
         breadcrumbs={[{ key: 'billing', label: t('header.billing') }, { key: 'billing-overview', label: t('billing.overview.title'), active: true }]}
-        actions={<><AppSelect clearable options={channelOptions} value={channelID} placeholder={t('billing.overview.channel_placeholder')} onChange={(e, { value }) => setChannelID((value || '').toString())} /><AppSelect clearable options={modelOptions} value={modelName} placeholder={t('billing.overview.model_placeholder')} onChange={(e, { value }) => setModelName((value || '').toString())} /><AppButton className='router-page-button' color='blue' loading={loading} onClick={() => load().then()}>{t('common.refresh')}</AppButton></>}
+        actions={<><AppSelect className='billing-overview-channel-select' clearable search options={channelOptions} value={channelID} placeholder={t('billing.overview.channel_placeholder')} onChange={(e, { value }) => setChannelID((value || '').toString())} /><AppSelect className='billing-overview-model-select' clearable search options={modelOptions} value={modelName} placeholder={t('billing.overview.model_placeholder')} onChange={(e, { value }) => setModelName((value || '').toString())} /><AppButton className='router-page-button' color='blue' loading={loading} onClick={() => load().then()}>{t('common.refresh')}</AppButton></>}
       />
       <div className='billing-overview-map' role='note'>
         <strong>{t('billing.overview.structure.title')}</strong>

--- a/web/src/pages/BillingOverview/index.jsx
+++ b/web/src/pages/BillingOverview/index.jsx
@@ -22,6 +22,28 @@ const recentRange = () => {
   return { start_at: end - 7 * 24 * 60 * 60, end_at: end };
 };
 
+const buildOperatingRisks = (items, t) => {
+  const risks = [];
+  (Array.isArray(items) ? items : []).forEach((item) => {
+    const model = item.dimension_name || item.dimension_key || '-';
+    const requests = Number(item.request_count || 0);
+    const unconfigured = Number(item.unconfigured_cost_request_count || 0);
+    const estimated = Number(item.estimated_cost_request_count || 0);
+    const pending = Number(item.pending_cost_request_count || 0);
+    const configured = Number(item.configured_cost_request_count || 0);
+    const profit = Number(item.gross_profit_base_amount || 0);
+    const margin = Number(item.gross_margin || 0);
+    const floorCount = Number(item.cost_floor_triggered_count || 0);
+    if (unconfigured > 0) risks.push({ key: `${model}-unconfigured`, level: 'critical', weight: unconfigured, text: t('billing.overview.operating_risks.unconfigured', { model, count: formatCount(unconfigured) }) });
+    if (configured > 0 && profit < 0) risks.push({ key: `${model}-loss`, level: 'critical', weight: Math.abs(profit), text: t('billing.overview.operating_risks.loss', { model, amount: formatCNY(profit) }) });
+    else if (configured > 0 && margin < 0.1) risks.push({ key: `${model}-low-margin`, level: 'warning', weight: requests, text: t('billing.overview.operating_risks.low_margin', { model, margin: formatPercent(margin) }) });
+    if (floorCount > 0) risks.push({ key: `${model}-floor`, level: 'warning', weight: floorCount, text: t('billing.overview.operating_risks.floor', { model, count: formatCount(floorCount) }) });
+    if (estimated > 0) risks.push({ key: `${model}-estimated`, level: 'warning', weight: estimated, text: t('billing.overview.operating_risks.estimated', { model, count: formatCount(estimated) }) });
+    if (pending > 0) risks.push({ key: `${model}-pending`, level: 'warning', weight: pending, text: t('billing.overview.operating_risks.pending', { model, count: formatCount(pending) }) });
+  });
+  return risks.sort((left, right) => (left.level === right.level ? right.weight - left.weight : left.level === 'critical' ? -1 : 1)).slice(0, 5);
+};
+
 const normalize = (payload) => ({
   request_count: Number(payload?.request_count || 0),
   router_consumed_yyc: Number(payload?.router_consumed_yyc || 0),
@@ -33,6 +55,10 @@ const normalize = (payload) => ({
   estimated_cost_request_count: Number(payload?.estimated_cost_request_count || 0),
   pending_cost_request_count: Number(payload?.pending_cost_request_count || 0),
   unconfigured_cost_request_count: Number(payload?.unconfigured_cost_request_count || 0),
+  input_quantity: Number(payload?.input_quantity || 0),
+  output_quantity: Number(payload?.output_quantity || 0),
+  cache_read_quantity: Number(payload?.cache_read_quantity || 0),
+  cache_write_quantity: Number(payload?.cache_write_quantity || 0),
   cost_floor_triggered_count: Number(payload?.cost_floor_triggered_count || 0),
   cost_floor_triggered_amount: Number(payload?.cost_floor_triggered_amount || 0),
   items: Array.isArray(payload?.items) ? payload.items : [],
@@ -42,33 +68,46 @@ function BillingOverview() {
   const { t } = useTranslation();
   const [loading, setLoading] = useState(false);
   const [report, setReport] = useState(() => normalize({}));
+  const [modelReport, setModelReport] = useState(() => normalize({}));
   const [health, setHealth] = useState({ status: 'ok', issues: [], critical_count: 0, warning_count: 0 });
   const [trend, setTrend] = useState([]);
   const [channelID, setChannelID] = useState('');
   const [modelName, setModelName] = useState('');
+  const [channelOptions, setChannelOptions] = useState([]);
   const [modelOptions, setModelOptions] = useState([]);
 
   const load = useCallback(async () => {
     setLoading(true);
     const range = recentRange();
     try {
-      const [reportResponse, modelReportResponse, healthResponse, trendResponse] = await Promise.all([
+      const filters = { channel_id: channelID, model: modelName };
+      const [reportResponse, filteredModelResponse, modelOptionsResponse, channelOptionsResponse, healthResponse, trendResponse] = await Promise.all([
         API.get('/api/v1/admin/billing/procurement-report', {
-          params: { ...range, group_by: 'channel', cost_scope: 'all' },
+          params: { ...range, group_by: 'channel', cost_scope: 'all', ...filters },
+        }),
+        API.get('/api/v1/admin/billing/procurement-report', {
+          params: { ...range, group_by: 'model', cost_scope: 'all', ...filters },
         }),
         API.get('/api/v1/admin/billing/procurement-report', {
           params: { ...range, group_by: 'model', cost_scope: 'all' },
         }),
+        API.get('/api/v1/admin/billing/procurement-report', {
+          params: { ...range, group_by: 'channel', cost_scope: 'all' },
+        }),
         API.get('/api/v1/admin/billing/health'),
-        API.get('/api/v1/admin/billing/procurement-trend', { params: { ...range, channel_id: channelID, model: modelName } }),
+        API.get('/api/v1/admin/billing/procurement-trend', { params: { ...range, ...filters } }),
       ]);
       if (reportResponse.data?.success) {
         setReport(normalize(reportResponse.data.data));
       } else {
         showError(reportResponse.data?.message || t('billing.overview.load_failed'));
       }
-      if (modelReportResponse.data?.success) {
-        setModelOptions((Array.isArray(modelReportResponse.data?.data?.items) ? modelReportResponse.data.data.items : []).map((item) => ({ key: item.dimension_key, value: item.dimension_key, text: item.dimension_key })));
+      if (filteredModelResponse.data?.success) setModelReport(normalize(filteredModelResponse.data.data));
+      if (modelOptionsResponse.data?.success) {
+        setModelOptions((Array.isArray(modelOptionsResponse.data?.data?.items) ? modelOptionsResponse.data.data.items : []).map((item) => ({ key: item.dimension_key, value: item.dimension_key, text: item.dimension_key })));
+      }
+      if (channelOptionsResponse.data?.success) {
+        setChannelOptions((Array.isArray(channelOptionsResponse.data?.data?.items) ? channelOptionsResponse.data.data.items : []).map((item) => ({ key: item.dimension_key, value: item.dimension_key, text: item.dimension_key })));
       }
       if (healthResponse.data?.success) {
         setHealth(healthResponse.data.data || {});
@@ -95,17 +134,23 @@ function BillingOverview() {
     [t('billing.overview.metrics.floor_triggered'), formatCount(report.cost_floor_triggered_count)],
     [t('billing.overview.metrics.floor_amount'), formatCNY(report.cost_floor_triggered_amount)],
   ];
+  const tokenCards = [
+    [t('billing.overview.tokens.input'), formatCount(report.input_quantity)],
+    [t('billing.overview.tokens.output'), formatCount(report.output_quantity)],
+    [t('billing.overview.tokens.cache_read'), formatCount(report.cache_read_quantity)],
+    [t('billing.overview.tokens.cache_write'), formatCount(report.cache_write_quantity)],
+  ];
   const knownCostCount = report.configured_cost_request_count;
-  const totalCostStateCount = knownCostCount + report.estimated_cost_request_count + report.pending_cost_request_count + report.unconfigured_cost_request_count;
-  const knownRatio = totalCostStateCount > 0 ? knownCostCount / totalCostStateCount : 0;
-  const topRisks = (Array.isArray(health.issues) ? health.issues : []).slice(0, 5);
+  const knownRatio = report.request_count > 0 ? knownCostCount / report.request_count : 0;
+  const operatingRisks = buildOperatingRisks(modelReport.items, t);
+  const configurationRisks = (Array.isArray(health.issues) ? health.issues : []).slice(0, 5);
   const topChannels = report.items.slice(0, 5);
 
   return (
     <div className='dashboard-container billing-overview-page'>
       <AppFilterHeader
         breadcrumbs={[{ key: 'billing', label: t('header.billing') }, { key: 'billing-overview', label: t('billing.overview.title'), active: true }]}
-        actions={<><AppSelect clearable options={report.items.map((item) => ({ key: item.dimension_key, value: item.dimension_key, text: item.dimension_key }))} value={channelID} placeholder={t('billing.overview.channel_placeholder')} onChange={(e, { value }) => setChannelID((value || '').toString())} /><AppSelect clearable options={modelOptions} value={modelName} placeholder={t('billing.overview.model_placeholder')} onChange={(e, { value }) => setModelName((value || '').toString())} /><AppButton className='router-page-button' color='blue' loading={loading} onClick={() => load().then()}>{t('common.refresh')}</AppButton></>}
+        actions={<><AppSelect clearable options={channelOptions} value={channelID} placeholder={t('billing.overview.channel_placeholder')} onChange={(e, { value }) => setChannelID((value || '').toString())} /><AppSelect clearable options={modelOptions} value={modelName} placeholder={t('billing.overview.model_placeholder')} onChange={(e, { value }) => setModelName((value || '').toString())} /><AppButton className='router-page-button' color='blue' loading={loading} onClick={() => load().then()}>{t('common.refresh')}</AppButton></>}
       />
       <div className='billing-overview-map' role='note'>
         <strong>{t('billing.overview.structure.title')}</strong>
@@ -118,6 +163,10 @@ function BillingOverview() {
           <div className='billing-overview-metric-grid'>
             {metricCards.map(([label, value]) => <div className='billing-overview-metric' key={label}><div className='billing-overview-label'>{label}</div><div className='billing-overview-value'>{value}</div></div>)}
           </div>
+          <div className='billing-overview-section-heading billing-overview-token-heading'><h2>{t('billing.overview.tokens.title')}</h2></div>
+          <div className='billing-overview-token-grid'>
+            {tokenCards.map(([label, value]) => <div className='billing-overview-token' key={label}><span>{label}</span><strong>{value}</strong></div>)}
+          </div>
           <div className={`billing-overview-confidence is-${knownRatio >= 0.8 ? 'good' : 'warning'}`}>
             <div><strong>{t('billing.overview.confidence.title')}</strong><span>{t('billing.overview.confidence.coverage', { value: formatPercent(knownRatio) })}</span></div>
             <div className='billing-overview-confidence-bar'><span style={{ width: `${Math.min(100, knownRatio * 100)}%` }} /></div>
@@ -126,17 +175,21 @@ function BillingOverview() {
         </AppSection>
         <div className='billing-overview-columns'>
           <AppSection className='billing-overview-section'>
-            <div className='billing-overview-section-heading'><h2>{t('billing.overview.risks.title')}</h2><Link to='/admin/billing/procurement-report'>{t('billing.overview.risks.view_details')}</Link></div>
-            {topRisks.length === 0 ? <div className='billing-overview-empty'>{t('billing.overview.risks.empty')}</div> : topRisks.map((issue) => <div className='billing-overview-risk' key={issue.key}><AppTag color={issue.level === 'critical' ? 'red' : 'orange'}>{t(`billing.procurement_report.health.level.${issue.level || 'warning'}`)}</AppTag><span title={issue.message}>{issue.title}{issue.count ? ` (${formatCount(issue.count)})` : ''}</span></div>)}
+            <div className='billing-overview-section-heading'><h2>{t('billing.overview.operating_risks.title')}</h2><Link to='/admin/billing/pricing-analysis'>{t('billing.overview.operating_risks.view_details')}</Link></div>
+            {operatingRisks.length === 0 ? <div className='billing-overview-empty'>{t('billing.overview.operating_risks.empty')}</div> : operatingRisks.map((issue) => <div className='billing-overview-risk' key={issue.key}><AppTag color={issue.level === 'critical' ? 'red' : 'orange'}>{t(`billing.procurement_report.health.level.${issue.level}`)}</AppTag><span title={issue.text}>{issue.text}</span></div>)}
           </AppSection>
           <AppSection className='billing-overview-section'>
             <div className='billing-overview-section-heading'><h2>{t('billing.overview.channels.title')}</h2><Link to='/admin/billing/procurement-report'>{t('billing.overview.channels.view_details')}</Link></div>
             {topChannels.length === 0 ? <div className='billing-overview-empty'>{t('billing.overview.channels.empty')}</div> : topChannels.map((item) => <div className='billing-overview-channel' key={item.dimension_key}><span>{item.dimension_name || item.dimension_key}</span><strong>{item.cost_floor_triggered_count > 0 ? `${formatCount(item.cost_floor_triggered_count)} / ${formatCNY(item.cost_floor_triggered_amount)}` : formatCNY(item.gross_profit_base_amount)}</strong></div>)}
           </AppSection>
         </div>
+        <AppSection className='billing-overview-section billing-overview-global-risks'>
+          <div className='billing-overview-section-heading'><h2>{t('billing.overview.configuration_risks.title')}</h2><Link to='/admin/billing/procurement-report'>{t('billing.overview.configuration_risks.view_details')}</Link></div>
+          {configurationRisks.length === 0 ? <div className='billing-overview-empty'>{t('billing.overview.configuration_risks.empty')}</div> : configurationRisks.map((issue) => <div className='billing-overview-risk' key={issue.key}><AppTag color={issue.level === 'critical' ? 'red' : 'orange'}>{t(`billing.procurement_report.health.level.${issue.level || 'warning'}`)}</AppTag><span title={issue.message}>{issue.title}{issue.count ? ` (${formatCount(issue.count)})` : ''}</span></div>)}
+        </AppSection>
         <AppSection className='billing-overview-section'>
           <div className='billing-overview-section-heading'><h2>{t('billing.overview.trend.title')}</h2></div>
-          <div className='billing-overview-trend'>{trend.map((item) => <div className='billing-overview-channel' key={item.day}><span>{item.day}</span><strong>{`${formatCount(item.cost_floor_triggered_count)} / ${formatCNY(item.cost_floor_triggered_amount)}`}</strong></div>)}</div>
+          <div className='billing-overview-trend'>{trend.map((item) => <div className='billing-overview-trend-row' key={item.day}><span>{item.day}</span><span>{t('billing.overview.trend.tokens', { input: formatCount(item.input_quantity), output: formatCount(item.output_quantity) })}</span><span>{t('billing.overview.trend.financials', { revenue: formatCNY(item.sell_base_amount), cost: formatCNY(item.procurement_cost_base_amount), profit: formatCNY(item.gross_profit_base_amount) })}</span><strong>{t('billing.overview.trend.coverage', { configured: formatCount(item.configured_cost_request_count), total: formatCount(item.request_count) })}</strong></div>)}</div>
         </AppSection>
       </AppSpin>
     </div>


### PR DESCRIPTION
## Summary
- require formal procurement cost readiness before publishing channel models
- add filtered token, revenue, cost, profit, and operating-risk visibility to the billing overview
- treat the external Billing service as optional so channel management remains available in manual billing mode
- improve billing overview labels and channel/model filters

## Verification
- `go test ./...`
- `npm --prefix web run build`
- `git diff --check`