### PR TITLE
Refine channel billing and finance procurement UX

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ VITE_SERVER=http://localhost:3011 npm run dev
 - `database.sql_dsn`：必填，且只支持 PostgreSQL DSN。
 - `auth.cookie_secret`：不要保留模板中的示例值 `random_string`。
 - `auth.jwt_secret`：钱包登录的 access/refresh token 签发与校验依赖该字段；留空会导致相关流程不可用。
-- `server.address`：用于密码重置链接、支付回调与跳转 URL 组装；对外部署时应填写可访问地址。
+- `server.public_url`：用于密码重置链接、支付回调与跳转 URL 组装；对外部署时应填写包含协议的可访问 URL。
 - `cache.type`：缓存后端类型，只支持 `local` 或 `redis`；留空时按旧配置兼容推断。
 - `redis.conn_string`：当 `cache.type: redis` 时必填，例如 `redis://:password@127.0.0.1:6379/0`。
 - `billing_service.base_url`：渠道账务自动刷新调用独立 Billing 服务的 `/api/v1/internal/billing:query`；Router 不再直接接入各渠道账务接口。
@@ -168,7 +168,7 @@ cp config.yaml.template config.yaml
 - `database.sql_dsn`：必填，且只支持 PostgreSQL DSN。
 - `auth.cookie_secret`：必须替换模板示例值。
 - `auth.jwt_secret`：如需钱包登录与 refresh token，必须配置。
-- `server.address`：如需密码重置链接、支付回调或跳转链接，必须配置为对外可访问地址。
+- `server.public_url`：如需密码重置链接、支付回调或跳转链接，必须配置为包含协议的对外可访问 URL。
 - `cache.type`：缓存后端类型，只支持 `local` 或 `redis`；使用 Redis 时必须同时配置 `redis.conn_string`。
 - `ucan.aud`：公网部署或域名/端口非默认值时，建议显式配置。
 - `bootstrap.root_wallet_address`：按需配置系统级用户管理钱包地址。

--- a/common/config/topup.go
+++ b/common/config/topup.go
@@ -135,7 +135,7 @@ func TopUpModeIssues() []string {
 func TopUpCreateIssues() []string {
 	issues := append(make([]string, 0, 3), TopUpModeIssues()...)
 	if strings.TrimSpace(ServerAddress) == "" {
-		issues = append(issues, "server.address is empty")
+		issues = append(issues, "server.public_url is empty")
 	}
 	if strings.TrimSpace(TopUpSignSecret) == "" {
 		issues = append(issues, "operation.top_up_sign_secret is empty")

--- a/common/config_loader.go
+++ b/common/config_loader.go
@@ -51,10 +51,10 @@ type AppConfig struct {
 }
 
 type ServerConfig struct {
-	Port    int    `yaml:"port"`
-	GinMode string `yaml:"gin_mode"`
-	LogDir  string `yaml:"log_dir"`
-	Address string `yaml:"address"`
+	Port      int    `yaml:"port"`
+	GinMode   string `yaml:"gin_mode"`
+	LogDir    string `yaml:"log_dir"`
+	PublicURL string `yaml:"public_url"`
 }
 
 type DatabaseConfig struct {
@@ -187,10 +187,10 @@ type LoggingConfig struct {
 func defaultAppConfig() AppConfig {
 	return AppConfig{
 		Server: ServerConfig{
-			Port:    3011,
-			GinMode: "release",
-			LogDir:  "./logs",
-			Address: "",
+			Port:      3011,
+			GinMode:   "release",
+			LogDir:    "./logs",
+			PublicURL: "",
 		},
 		Database: DatabaseConfig{
 			SQLDSN:             "postgres://postgres:postgres@127.0.0.1:5432/postgres?sslmode=disable",
@@ -345,8 +345,8 @@ func ApplyAppConfig(cfg *AppConfig, portFlagSet bool, logDirFlagSet bool) error 
 	}
 
 	GinMode = normalizeGinMode(cfg.Server.GinMode)
-	if serverAddress := strings.TrimSpace(cfg.Server.Address); serverAddress != "" {
-		config.ServerAddress = serverAddress
+	if publicURL := strings.TrimSpace(cfg.Server.PublicURL); publicURL != "" {
+		config.ServerAddress = publicURL
 	}
 	DisableOpenAICompat = cfg.Feature.DisableOpenAICompat
 	FrontendBaseURL = strings.TrimSpace(cfg.Feature.FrontendBaseURL)

--- a/config.yaml.template
+++ b/config.yaml.template
@@ -17,7 +17,7 @@ server:
   # - 密码重置链接
   # - 支付回调与跳转 URL 组装
   # 例： https://router.example.com
-  address: ""
+  public_url: ""
 
 database:
   # 主业务数据库 DSN（仅支持 PostgreSQL）。
@@ -235,10 +235,6 @@ metrics:
   queue_size: 10
   # 成功率阈值（0~1）。
   success_rate_threshold: 0.8
-  # 成功事件缓冲通道大小。
-  success_chan_size: 1024
-  # 失败事件缓冲通道大小。
-  fail_chan_size: 128
   # 低成功率自动禁用后的恢复等待时间（秒）；设置为 0 或负数时使用默认 300 秒。
   auto_recover_after_seconds: 300
 

--- a/internal/admin/controller/channel/billing_service_client.go
+++ b/internal/admin/controller/channel/billing_service_client.go
@@ -261,7 +261,11 @@ func resolveChannelBillingBaseURL(channel *model.Channel) string {
 	if channel == nil {
 		return ""
 	}
-	return strings.TrimSpace(channel.ResolveAPIBaseURL(""))
+	cfg, err := channel.LoadConfig()
+	if err != nil {
+		return ""
+	}
+	return strings.TrimRight(strings.TrimSpace(cfg.AccountBaseURL), "/")
 }
 
 func buildBillingServiceQuery(ctx context.Context, channel *model.Channel, profile model.ChannelBillingProfile) (billingServiceQueryRequest, error) {

--- a/internal/admin/controller/channel/billing_service_client.go
+++ b/internal/admin/controller/channel/billing_service_client.go
@@ -23,7 +23,6 @@ const (
 type billingServiceQueryRequest struct {
 	ChannelID   string            `json:"channel_id,omitempty"`
 	Adapter     string            `json:"adapter"`
-	BaseURL     string            `json:"base_url,omitempty"`
 	Credentials map[string]string `json:"credentials,omitempty"`
 	Config      map[string]any    `json:"config,omitempty"`
 }
@@ -257,17 +256,6 @@ func missingRequiredBillingCredentialField(fields []billingServiceCredentialFiel
 	return ""
 }
 
-func resolveChannelBillingBaseURL(channel *model.Channel) string {
-	if channel == nil {
-		return ""
-	}
-	cfg, err := channel.LoadConfig()
-	if err != nil {
-		return ""
-	}
-	return strings.TrimRight(strings.TrimSpace(cfg.AccountBaseURL), "/")
-}
-
 func buildBillingServiceQuery(ctx context.Context, channel *model.Channel, profile model.ChannelBillingProfile) (billingServiceQueryRequest, error) {
 	if channel == nil {
 		return billingServiceQueryRequest{}, fmt.Errorf("渠道不存在")
@@ -290,7 +278,6 @@ func buildBillingServiceQuery(ctx context.Context, channel *model.Channel, profi
 	request := billingServiceQueryRequest{
 		ChannelID:   strings.TrimSpace(channel.Id),
 		Adapter:     adapter,
-		BaseURL:     resolveChannelBillingBaseURL(channel),
 		Credentials: credentials,
 	}
 	return request, nil

--- a/internal/admin/controller/channel/billing_service_client_test.go
+++ b/internal/admin/controller/channel/billing_service_client_test.go
@@ -133,6 +133,7 @@ func TestBuildBillingServiceQueryUsesAdapterProtocol(t *testing.T) {
 		Protocol: "vendor-protocol",
 		Key:      "model-secret-must-not-be-used",
 		BaseURL:  &baseURL,
+		Config:   `{"account_base_url":"https://billing.vendor.example.com/"}`,
 	}, profile)
 	if err != nil {
 		t.Fatal(err)
@@ -140,7 +141,7 @@ func TestBuildBillingServiceQueryUsesAdapterProtocol(t *testing.T) {
 	if query.Adapter != "vendor-a" {
 		t.Fatalf("adapter = %q", query.Adapter)
 	}
-	if query.BaseURL != baseURL {
+	if query.BaseURL != "https://billing.vendor.example.com" {
 		t.Fatalf("base_url = %q", query.BaseURL)
 	}
 	if query.Credentials["key"] != "billing-secret" {
@@ -158,6 +159,34 @@ func TestBuildBillingServiceQueryUsesAdapterProtocol(t *testing.T) {
 	}
 	if strings.Contains(string(body), "credential\"") {
 		t.Fatalf("query must not use legacy credential field: %s", body)
+	}
+}
+
+func TestBuildBillingServiceQueryUsesAccountBaseURL(t *testing.T) {
+	configureBillingServiceForTest(t, func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != billingServiceAdaptersPath {
+			http.Error(w, "unexpected path", http.StatusNotFound)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"data":[{"name":"aixhan","credential_fields":[{"name":"cdk","required":true}]}]}`))
+	}, "")
+
+	baseURL := "https://api.aixhan.com"
+	channel := &model.Channel{
+		Id:      "channel-aixhan",
+		BaseURL: &baseURL,
+		Config:  `{"api_base_url":"https://api.aixhan.com","account_base_url":"https://cdk.aixhan.com/"}`,
+	}
+	query, err := buildBillingServiceQuery(context.Background(), channel, model.ChannelBillingProfile{
+		BillingSource: "aixhan",
+		BillingConfig: `{"billing_credentials":{"cdk":"test-cdk"}}`,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if query.BaseURL != "https://cdk.aixhan.com" {
+		t.Fatalf("base_url = %q", query.BaseURL)
 	}
 }
 

--- a/internal/admin/controller/channel/billing_service_client_test.go
+++ b/internal/admin/controller/channel/billing_service_client_test.go
@@ -127,22 +127,16 @@ func TestBuildBillingServiceQueryUsesAdapterProtocol(t *testing.T) {
 		BillingSource: "vendor-a",
 		BillingConfig: `{"billing_credentials":{"key":"billing-secret"}}`,
 	}
-	baseURL := "https://vendor.example.com"
 	query, err := buildBillingServiceQuery(context.Background(), &model.Channel{
 		Id:       "channel-1",
 		Protocol: "vendor-protocol",
 		Key:      "model-secret-must-not-be-used",
-		BaseURL:  &baseURL,
-		Config:   `{"account_base_url":"https://billing.vendor.example.com/"}`,
 	}, profile)
 	if err != nil {
 		t.Fatal(err)
 	}
 	if query.Adapter != "vendor-a" {
 		t.Fatalf("adapter = %q", query.Adapter)
-	}
-	if query.BaseURL != "https://billing.vendor.example.com" {
-		t.Fatalf("base_url = %q", query.BaseURL)
 	}
 	if query.Credentials["key"] != "billing-secret" {
 		t.Fatalf("credentials = %+v", query.Credentials)
@@ -160,33 +154,8 @@ func TestBuildBillingServiceQueryUsesAdapterProtocol(t *testing.T) {
 	if strings.Contains(string(body), "credential\"") {
 		t.Fatalf("query must not use legacy credential field: %s", body)
 	}
-}
-
-func TestBuildBillingServiceQueryUsesAccountBaseURL(t *testing.T) {
-	configureBillingServiceForTest(t, func(w http.ResponseWriter, r *http.Request) {
-		if r.URL.Path != billingServiceAdaptersPath {
-			http.Error(w, "unexpected path", http.StatusNotFound)
-			return
-		}
-		w.Header().Set("Content-Type", "application/json")
-		_, _ = w.Write([]byte(`{"data":[{"name":"aixhan","credential_fields":[{"name":"cdk","required":true}]}]}`))
-	}, "")
-
-	baseURL := "https://api.aixhan.com"
-	channel := &model.Channel{
-		Id:      "channel-aixhan",
-		BaseURL: &baseURL,
-		Config:  `{"api_base_url":"https://api.aixhan.com","account_base_url":"https://cdk.aixhan.com/"}`,
-	}
-	query, err := buildBillingServiceQuery(context.Background(), channel, model.ChannelBillingProfile{
-		BillingSource: "aixhan",
-		BillingConfig: `{"billing_credentials":{"cdk":"test-cdk"}}`,
-	})
-	if err != nil {
-		t.Fatal(err)
-	}
-	if query.BaseURL != "https://cdk.aixhan.com" {
-		t.Fatalf("base_url = %q", query.BaseURL)
+	if strings.Contains(string(body), "base_url") {
+		t.Fatalf("billing query must not expose upstream address: %s", body)
 	}
 }
 

--- a/internal/admin/model/channel.go
+++ b/internal/admin/model/channel.go
@@ -66,6 +66,7 @@ type ChannelConfig struct {
 	LibraryID         string `json:"library_id,omitempty"`
 	Plugin            string `json:"plugin,omitempty"`
 	APIBaseURL        string `json:"api_base_url,omitempty"`
+	AccountBaseURL    string `json:"account_base_url,omitempty"`
 	VertexAIProjectID string `json:"vertex_ai_project_id,omitempty"`
 	VertexAIADC       string `json:"vertex_ai_adc,omitempty"`
 }

--- a/internal/admin/model/channel.go
+++ b/internal/admin/model/channel.go
@@ -66,7 +66,6 @@ type ChannelConfig struct {
 	LibraryID         string `json:"library_id,omitempty"`
 	Plugin            string `json:"plugin,omitempty"`
 	APIBaseURL        string `json:"api_base_url,omitempty"`
-	AccountBaseURL    string `json:"account_base_url,omitempty"`
 	VertexAIProjectID string `json:"vertex_ai_project_id,omitempty"`
 	VertexAIADC       string `json:"vertex_ai_adc,omitempty"`
 }

--- a/web/src/components/AdminSidebar.jsx
+++ b/web/src/components/AdminSidebar.jsx
@@ -101,16 +101,11 @@ const AdminSidebar = ({ compact = false }) => {
     <AppNavMenu
       className='router-admin-nav-menu'
       mode='inline'
-      inlineCollapsed={compact}
       triggerSubMenuAction={compact ? 'click' : 'hover'}
       items={items}
       selectedKeys={selectedKeys}
-      {...(!compact
-        ? {
-            openKeys,
-            onOpenChange: (nextKeys) => setOpenKeys(nextKeys),
-          }
-        : {})}
+      openKeys={openKeys}
+      onOpenChange={(nextKeys) => setOpenKeys(nextKeys)}
       onClick={({ key }) => {
         if (typeof key === 'string' && key.startsWith('/')) {
           navigate(key);

--- a/web/src/components/ChannelsTable.jsx
+++ b/web/src/components/ChannelsTable.jsx
@@ -336,13 +336,19 @@ const ChannelsTable = () => {
   const searchChannels = async () => {
     setSearching(true);
     setLoading(true);
-    await loadChannels({ page: 1, keyword: searchKeyword });
-    setActivePage(1);
-    setSearching(false);
+    try {
+      await loadChannels({ page: 1, keyword: searchKeyword });
+      setActivePage(1);
+    } catch (error) {
+      showError(error?.message || String(error));
+      setLoading(false);
+    } finally {
+      setSearching(false);
+    }
   };
 
-  const handleKeywordChange = async (e, { value }) => {
-    setSearchKeyword(value.trim());
+  const handleKeywordChange = (e, { value }) => {
+    setSearchKeyword(value);
   };
 
   const handleTableChange = (_, __, sorter) => {
@@ -614,6 +620,7 @@ const ChannelsTable = () => {
               value={searchKeyword}
               loading={searching}
               onChange={handleKeywordChange}
+              onPressEnter={searchChannels}
             />
           </div>
         }

--- a/web/src/components/UserSidebar.jsx
+++ b/web/src/components/UserSidebar.jsx
@@ -123,16 +123,11 @@ const UserSidebar = ({ compact = false }) => {
     <AppNavMenu
       className='router-admin-nav-menu router-user-nav-menu'
       mode='inline'
-      inlineCollapsed={compact}
       triggerSubMenuAction={compact ? 'click' : 'hover'}
       items={items}
       selectedKeys={selectedKeys}
-      {...(!compact
-        ? {
-            openKeys,
-            onOpenChange: (nextKeys) => setOpenKeys(nextKeys),
-          }
-        : {})}
+      openKeys={openKeys}
+      onOpenChange={(nextKeys) => setOpenKeys(nextKeys)}
       onClick={({ key }) => {
         if (typeof key === 'string' && key.startsWith('/')) {
           navigate(key);

--- a/web/src/index.css
+++ b/web/src/index.css
@@ -5269,55 +5269,6 @@ body,
     min-height: 36px;
 }
 
-.router-billing-upstream-view {
-    display: flex;
-    flex-direction: column;
-    gap: 14px;
-}
-
-.router-billing-overview-strip {
-    display: flex;
-    align-items: center;
-    justify-content: space-between;
-    gap: 16px;
-    padding: 14px 16px;
-    border: 1px solid rgba(15, 23, 42, 0.08);
-    border-radius: 14px;
-    background:
-        linear-gradient(135deg, rgba(248, 250, 252, 0.96), rgba(241, 245, 249, 0.86)),
-        #f8fafc;
-}
-
-.router-billing-overview-main {
-    display: inline-flex;
-    align-items: center;
-    gap: 10px;
-    min-width: 0;
-    color: var(--router-text-secondary, rgba(0, 0, 0, 0.66));
-    font-size: 13px;
-    line-height: 1.45;
-}
-
-.router-billing-overview-main > span:last-child {
-    min-width: 0;
-}
-
-.router-billing-overview-meta {
-    display: inline-flex;
-    align-items: baseline;
-    gap: 8px;
-    color: #6b7280;
-    font-size: 12px;
-    line-height: 1.4;
-    white-space: nowrap;
-}
-
-.router-billing-overview-meta strong {
-    color: #111827;
-    font-size: 13px;
-    font-weight: 600;
-}
-
 .router-billing-snapshot-time {
     color: var(--router-text-muted, rgba(0, 0, 0, 0.5));
     font-size: 13px;
@@ -5434,7 +5385,6 @@ body,
 
 @media (max-width: 768px) {
     .router-billing-workspace-toolbar,
-    .router-billing-overview-strip,
     .router-billing-subsection-header {
         align-items: stretch;
         flex-direction: column;
@@ -5444,9 +5394,6 @@ body,
         width: 100%;
     }
 
-    .router-billing-overview-meta {
-        justify-content: space-between;
-    }
 }
 
 .router-row-clickable {

--- a/web/src/index.css
+++ b/web/src/index.css
@@ -134,10 +134,6 @@ body,
 }
 
 .router-admin-sidebar {
-    width: 248px;
-    min-width: 248px !important;
-    max-width: 248px !important;
-    flex: 0 0 248px;
     border-right: 1px solid rgba(15, 23, 42, 0.06);
     background: #f8fafc !important;
     position: sticky;
@@ -145,27 +141,9 @@ body,
     height: calc(100vh - 64px);
     display: flex;
     flex-direction: column;
-    overflow: hidden;
+    overflow: visible;
     padding: 12px 10px 14px;
     box-shadow: inset -1px 0 0 rgba(255, 255, 255, 0.5);
-}
-
-.router-admin-sidebar-toolbar {
-    display: flex;
-    justify-content: flex-end;
-    align-items: center;
-    margin-bottom: 10px;
-    padding: 0 6px;
-    min-height: 36px;
-    flex: 0 0 auto;
-}
-
-.router-admin-sidebar.compact {
-    width: 84px;
-    min-width: 84px !important;
-    max-width: 84px !important;
-    flex: 0 0 84px;
-    padding: 12px 6px;
 }
 
 .router-admin-sidebar-scroll {
@@ -180,26 +158,28 @@ body,
     display: none;
 }
 
-.router-ui-button.router-admin-sidebar-toggle {
-    min-width: 32px;
-    min-height: 32px;
+.router-ui-button.router-admin-divider-toggle {
+    position: absolute;
+    z-index: 2;
+    top: 50%;
+    right: 0;
+    width: 18px;
+    min-width: 18px;
+    height: 40px;
+    min-height: 40px;
     padding: 0 !important;
-    border-radius: 10px !important;
+    border-radius: 6px !important;
     color: rgba(15, 23, 42, 0.68) !important;
-    box-shadow: none !important;
-    border-color: transparent !important;
-    background: rgba(255, 255, 255, 0.72) !important;
+    border-color: rgba(15, 23, 42, 0.12) !important;
+    background: #fff !important;
+    box-shadow: 0 1px 4px rgba(15, 23, 42, 0.12) !important;
+    transform: translate(50%, -50%);
 }
 
-.router-ui-button.router-admin-sidebar-toggle:hover,
-.router-ui-button.router-admin-sidebar-toggle:focus-visible {
-    background: rgba(255, 255, 255, 0.96) !important;
+.router-ui-button.router-admin-divider-toggle:hover,
+.router-ui-button.router-admin-divider-toggle:focus-visible {
+    background: #f8fafc !important;
     color: rgba(15, 23, 42, 0.92) !important;
-}
-
-.router-admin-sidebar.compact .router-admin-sidebar-toolbar {
-    justify-content: center;
-    padding: 0;
 }
 
 .router-admin-main {

--- a/web/src/layouts/AdminLayout.jsx
+++ b/web/src/layouts/AdminLayout.jsx
@@ -42,35 +42,29 @@ const AdminLayout = () => {
           collapsedWidth={84}
           collapsed={sidebarCompact}
         >
-          <div className='router-admin-sidebar-toolbar'>
-            <AppButton
-              type='button'
-              basic
-              size='small'
-              className='router-admin-sidebar-toggle'
-              title={
-                sidebarCompact
-                  ? t('header.sidebar_expand')
-                  : t('header.sidebar_compact')
-              }
-              aria-label={
-                sidebarCompact
-                  ? t('header.sidebar_expand')
-                  : t('header.sidebar_compact')
-              }
-              onClick={() => setSidebarCompact((previous) => !previous)}
-              icon={
-                sidebarCompact ? (
-                  <DoubleRightOutlined />
-                ) : (
-                  <DoubleLeftOutlined />
-                )
-              }
-            />
-          </div>
           <div className='router-admin-sidebar-scroll'>
             <AdminSidebar compact={sidebarCompact} />
           </div>
+          <AppButton
+            type='button'
+            basic
+            size='small'
+            className='router-admin-divider-toggle'
+            title={
+              sidebarCompact
+                ? t('header.sidebar_expand')
+                : t('header.sidebar_compact')
+            }
+            aria-label={
+              sidebarCompact
+                ? t('header.sidebar_expand')
+                : t('header.sidebar_compact')
+            }
+            onClick={() => setSidebarCompact((previous) => !previous)}
+            icon={
+              sidebarCompact ? <DoubleRightOutlined /> : <DoubleLeftOutlined />
+            }
+          />
         </AppSider>
         <div className='main-content router-admin-main'>
           <Outlet />

--- a/web/src/layouts/UserWorkspaceLayout.jsx
+++ b/web/src/layouts/UserWorkspaceLayout.jsx
@@ -42,35 +42,29 @@ const UserWorkspaceLayout = () => {
           collapsedWidth={84}
           collapsed={sidebarCompact}
         >
-          <div className='router-admin-sidebar-toolbar'>
-            <AppButton
-              type='button'
-              basic
-              size='small'
-              className='router-admin-sidebar-toggle'
-              title={
-                sidebarCompact
-                  ? t('header.sidebar_expand')
-                  : t('header.sidebar_compact')
-              }
-              aria-label={
-                sidebarCompact
-                  ? t('header.sidebar_expand')
-                  : t('header.sidebar_compact')
-              }
-              onClick={() => setSidebarCompact((previous) => !previous)}
-              icon={
-                sidebarCompact ? (
-                  <DoubleRightOutlined />
-                ) : (
-                  <DoubleLeftOutlined />
-                )
-              }
-            />
-          </div>
           <div className='router-admin-sidebar-scroll'>
             <AdminSidebar compact={sidebarCompact} />
           </div>
+          <AppButton
+            type='button'
+            basic
+            size='small'
+            className='router-admin-divider-toggle'
+            title={
+              sidebarCompact
+                ? t('header.sidebar_expand')
+                : t('header.sidebar_compact')
+            }
+            aria-label={
+              sidebarCompact
+                ? t('header.sidebar_expand')
+                : t('header.sidebar_compact')
+            }
+            onClick={() => setSidebarCompact((previous) => !previous)}
+            icon={
+              sidebarCompact ? <DoubleRightOutlined /> : <DoubleLeftOutlined />
+            }
+          />
         </AppSider>
         <div className='main-content router-admin-main'>
           <Outlet />

--- a/web/src/locales/en/translation.json
+++ b/web/src/locales/en/translation.json
@@ -788,7 +788,7 @@
         }
       },
       "billing": {
-        "structure_hint": "This page records upstream procurement for the channel. Purchase records create batches; request consumption turns batches into unit cost. It is separate from user payment records.",
+        "structure_hint": "This page records channel procurement facts. Purchase records create batches; request consumption turns batches into unit cost. It is separate from user payment records.",
         "title": "Billing",
         "hint": "This section shows standardized channel billing entitlements, not upstream-specific raw fields. The system tracks quotas, balances, credits, and plan validity as structured entitlement items, and uses those normalized fields for refresh, alerts, and future automation.",
         "load_failed": "Failed to load channel billing data",
@@ -799,13 +799,16 @@
         "profile_update_failed": "Failed to update billing profile",
         "refresh_now": "Refresh",
         "latest_refresh_failed": "Latest billing refresh failed: {{message}}",
-        "latest_refresh_failed_unknown": "Upstream billing API returned an error",
+        "latest_refresh_failed_unknown": "Billing service returned an error",
         "latest_snapshot_at": "Latest Refresh",
         "current_quotas_title": "Entitlement Status",
         "billing_source": "Billing Source",
         "updated_at": "Updated At",
         "manual_update_title": "Add Purchase Record",
         "manual_purchase_title": "Purchase Info",
+        "manual_channel": "Procurement Channel",
+        "manual_channel_placeholder": "Select procurement channel",
+        "manual_channel_required": "Please select a procurement channel",
         "manual_purchase_at": "Purchase Time",
         "manual_purchase_currency": "Purchase Currency",
         "manual_purchase_amount": "Paid Amount",
@@ -838,11 +841,11 @@
         "manual_resource_hints": {
           "default": "Items jointly constrain current usage. Periodic quotas reset daily, weekly, or monthly, while total quota keeps decreasing. If any applicable item is insufficient, the entitlement group cannot provide that usage.",
           "balance": "Balance: directly consumable account balance. Fill total, used, and remaining amount.",
-          "credit": "Credit: granted or promotional upstream credit. It is consumable like balance, but has a different source.",
+          "credit": "Credit: granted or promotional provider credit. It is consumable like balance, but has a different source.",
           "quota": "Quota: consumable usage capacity. Daily, weekly, and monthly quotas are package periodic quota rules; total quota is cumulative and decreases as it is used.",
           "periodic": "Periodic quota: enter the amount available in each period. It resets automatically, and unused quota does not carry over.",
           "total": "Total quota: cumulative consumable quota. It decreases as it is used and does not reset daily, weekly, or monthly.",
-          "source_ref": "Use the upstream original name as source reference for traceability."
+          "source_ref": "Use the provider original name as source reference for traceability."
         },
         "manual_plan_name": "Plan Name",
         "manual_plan_name_placeholder": "e.g. Monthly Plan / Quarterly Plan",
@@ -872,10 +875,9 @@
         "manual_valid_from": "Valid From (blank means immediately)",
         "manual_valid_until": "Valid Until (blank means no expiry)",
         "validity_immediate": "Immediately",
-        "upstream_status_title": "Upstream Status",
         "view_procurement": "View procurement cost",
         "procurement_title": "Procurement Batches",
-        "procurement_hint": "These are not upstream billing records. Procurement batches come from purchase records. Request settlement consumes capacity from these batches to calculate actual procurement cost.",
+        "procurement_hint": "These are not raw billing service records. Procurement batches come from purchase records. Request settlement consumes capacity from these batches to calculate actual procurement cost.",
         "procurement_edit_cost": "Edit Cost",
         "procurement_disable": "Disable",
         "procurement_restore": "Restore",
@@ -967,14 +969,6 @@
           "package": "Package",
           "plan": "Plan Validity",
           "custom": "Custom"
-        },
-        "mode_summary": {
-          "package_title": "Package Channel",
-          "package_description": "This channel has plan validity or periodic quota. Check expiration, daily/weekly/monthly remaining quota, and reset time before judging availability.",
-          "metered_title": "Metered Channel",
-          "metered_description": "This channel mainly deducts from balance or total credit. Exhausted credit can affect auto-disable decisions.",
-          "unknown_title": "Unknown",
-          "unknown_description": "The current snapshot has no recognizable metered or package entitlement items."
         },
         "quota_table": {
           "entitlement_kind": "Billing Type",
@@ -3483,7 +3477,7 @@
       "nav": "Procurement Cost",
       "title": "Procurement Cost",
       "empty": "No procurement cost data",
-      "management": { "title": "Procurement management", "channel_placeholder": "Select channel", "select_channel": "Select a channel to manage purchase records and procurement batches" },
+      "management": { "title": "Procurement management", "channel_placeholder": "All channels", "select_channel": "Select a channel to manage purchase records" },
       "health": {
         "status": {
           "ok": "Finance healthy",

--- a/web/src/locales/zh/translation.json
+++ b/web/src/locales/zh/translation.json
@@ -788,7 +788,7 @@
         }
       },
       "billing": {
-        "structure_hint": "这里维护该渠道的上游采购事实：采购记录生成采购批次，批次容量被请求消费后形成单位成本；它不是用户支付记录。",
+        "structure_hint": "这里维护该渠道的采购事实：采购记录生成采购批次，批次容量被请求消费后形成单位成本；它不是用户支付记录。",
         "title": "账务",
         "hint": "这里展示的是渠道账务权益项，不是上游原始字段。系统统一按权益项维护额度、余额、信用额度、套餐有效期等信息，并基于这些标准字段做刷新、告警和后续自动化动作。",
         "load_failed": "加载渠道账务信息失败",
@@ -799,13 +799,16 @@
         "profile_update_failed": "账务配置保存失败",
         "refresh_now": "刷新",
         "latest_refresh_failed": "最近一次账务刷新失败：{{message}}",
-        "latest_refresh_failed_unknown": "上游账务接口返回异常",
+        "latest_refresh_failed_unknown": "账务服务返回异常",
         "latest_snapshot_at": "最近刷新",
         "current_quotas_title": "权益项状态",
         "billing_source": "账务来源",
         "updated_at": "更新时间",
         "manual_update_title": "新增采购记录",
         "manual_purchase_title": "采购信息",
+        "manual_channel": "采购渠道",
+        "manual_channel_placeholder": "选择采购渠道",
+        "manual_channel_required": "请选择采购渠道",
         "manual_purchase_at": "采购时间",
         "manual_purchase_currency": "采购币种",
         "manual_purchase_amount": "实付金额",
@@ -838,11 +841,11 @@
         "manual_resource_hints": {
           "default": "权益项共同约束当前使用量。周期额度按日、周或月恢复，总额度持续递减；任一适用权益不足时，该权益组不能继续提供对应用量。",
           "balance": "余额：表示可直接消耗的账户余额，通常要填写总额度、已用额度和剩余额度。",
-          "credit": "信用额度：表示上游授信或赠送额度，本质上也是可消耗额度，但和余额来源不同。",
+          "credit": "信用额度：表示供应商授信或赠送额度，本质上也是可消耗额度，但和余额来源不同。",
           "quota": "额度：表示可消耗的调用容量。日/周/月额度是套餐周期额度规则；总额度是累计额度，用一点少一点。",
           "periodic": "周期额度：填写每个周期可使用的额度。到新周期自动恢复，未用完的额度不累计到下一周期。",
           "total": "总额度：填写累计可消耗额度，有效期内用一点少一点，不随日/周/月重置。",
-          "source_ref": "来源标识建议填写上游原始名称，方便追溯。"
+          "source_ref": "来源标识建议填写供应商原始名称，方便追溯。"
         },
         "manual_plan_name": "套餐名称",
         "manual_plan_name_placeholder": "例如：月套餐 / 季度套餐",
@@ -872,10 +875,9 @@
         "manual_valid_from": "有效期开始（留空立即生效）",
         "manual_valid_until": "有效期结束（留空永久有效）",
         "validity_immediate": "立即生效",
-        "upstream_status_title": "上游状态",
         "view_procurement": "查看采购成本",
         "procurement_title": "采购批次",
-        "procurement_hint": "这里不是上游账务明细。采购批次来自采购记录，请求结算时会从这些批次里扣容量，并计算实际采购成本。",
+        "procurement_hint": "这里不是账务服务原始明细。采购批次来自采购记录，请求结算时会从这些批次里扣容量，并计算实际采购成本。",
         "procurement_edit_cost": "补成本",
         "procurement_disable": "停用",
         "procurement_restore": "恢复",
@@ -967,14 +969,6 @@
           "package": "套餐",
           "plan": "套餐有效期",
           "custom": "自定义"
-        },
-        "mode_summary": {
-          "package_title": "套餐渠道",
-          "package_description": "该渠道存在套餐有效期或周期额度，运营判断可用性时优先看有效期、日/周/月剩余额度和重置时间。",
-          "metered_title": "按量渠道",
-          "metered_description": "该渠道主要按余额或总额度扣减，余额耗尽后会影响自动禁用判断。",
-          "unknown_title": "未识别",
-          "unknown_description": "当前快照没有可识别的按量或套餐权益项。"
         },
         "quota_table": {
           "entitlement_kind": "计费形态",
@@ -3478,7 +3472,7 @@
       "nav": "采购成本",
       "title": "采购成本",
       "empty": "暂无采购成本数据",
-      "management": { "title": "采购管理", "channel_placeholder": "选择采购渠道", "select_channel": "请选择渠道后维护采购记录和采购批次" },
+      "management": { "title": "采购管理", "channel_placeholder": "全部渠道", "select_channel": "请选择渠道后维护采购记录" },
       "health": {
         "status": {
           "ok": "财务健康",

--- a/web/src/pages/BillingProcurementReport/index.jsx
+++ b/web/src/pages/BillingProcurementReport/index.jsx
@@ -164,7 +164,11 @@ function BillingProcurementReport() {
   }, [managedChannelID, t]);
 
   const savePurchaseRecord = useCallback(async (payload) => {
-    if (!managedChannelID) return false;
+    const targetChannelID = String(payload?.channel_id || managedChannelID || '').trim();
+    if (!targetChannelID) {
+      showInfo(t('channel.edit.billing.manual_channel_required'));
+      return false;
+    }
     const items = (Array.isArray(payload?.items) ? payload.items : []).map((item) => ({
       id: String(item?.id || '').trim(),
       resource_type: String(item?.resource_type || '').trim(),
@@ -186,7 +190,7 @@ function BillingProcurementReport() {
     setProcurementSubmitting(true);
     try {
       const recordID = String(payload?.id || '').trim();
-      const path = `/api/v1/admin/channel/${encodeURIComponent(managedChannelID)}/billing/snapshots${recordID ? `/${encodeURIComponent(recordID)}` : ''}`;
+      const path = `/api/v1/admin/channel/${encodeURIComponent(targetChannelID)}/billing/snapshots${recordID ? `/${encodeURIComponent(recordID)}` : ''}`;
       const requestPayload = {
         id: recordID,
         purchase_at: Number(payload?.purchase_at || 0),
@@ -202,7 +206,7 @@ function BillingProcurementReport() {
       };
       const response = recordID ? await API.put(path, requestPayload) : await API.post(path, requestPayload);
       if (!response.data?.success) throw new Error(response.data?.message);
-      await loadProcurementManagement();
+      await loadProcurementManagement(managedChannelID);
       showSuccess(t('channel.edit.billing.manual_snapshot_success'));
       return true;
     } catch (error) {
@@ -726,25 +730,26 @@ function BillingProcurementReport() {
               onChange={(e, { value }) => setManagedChannelID(String(value || ''))}
             />
           </div>
-          {managedChannelID ? (
-            <ChannelDetailBillingTab
-              t={t}
-              billingSummary={null}
-              billingLoading={procurementLoading}
-              billingSnapshots={purchaseRecords}
-              procurementBatches={procurementBatches}
-              billingReadonly={false}
-              billingSubmitting={procurementSubmitting}
-              onManualSnapshotUpdate={savePurchaseRecord}
-              onManualSnapshotDelete={deletePurchaseRecord}
-              onProcurementBatchCostUpdate={(id, payload) => updateBatch(id, 'cost', payload, 'channel.edit.billing.procurement_update_success', 'channel.edit.billing.procurement_update_failed')}
-              onProcurementBatchStatusUpdate={(id, status) => updateBatch(id, 'status', { cost_status: status }, 'channel.edit.billing.procurement_status_update_success', 'channel.edit.billing.procurement_status_update_failed')}
-              onProcurementBatchConsumptionsLoad={loadBatchConsumptions}
-              timestamp2string={timestamp2string}
-              viewMode='procurement'
-              channelID={managedChannelID}
-            />
-          ) : <div className='billing-overview-empty'>{t('billing.procurement_report.management.select_channel')}</div>}
+          <ChannelDetailBillingTab
+            t={t}
+            billingSummary={null}
+            billingLoading={procurementLoading}
+            billingSnapshots={purchaseRecords}
+            procurementBatches={procurementBatches}
+            billingReadonly={false}
+            billingSubmitting={procurementSubmitting}
+            onManualSnapshotUpdate={savePurchaseRecord}
+            onManualSnapshotDelete={deletePurchaseRecord}
+            onProcurementBatchCostUpdate={(id, payload) => updateBatch(id, 'cost', payload, 'channel.edit.billing.procurement_update_success', 'channel.edit.billing.procurement_update_failed')}
+            onProcurementBatchStatusUpdate={(id, status) => updateBatch(id, 'status', { cost_status: status }, 'channel.edit.billing.procurement_status_update_success', 'channel.edit.billing.procurement_status_update_failed')}
+            onProcurementBatchConsumptionsLoad={loadBatchConsumptions}
+            timestamp2string={timestamp2string}
+            viewMode='procurement'
+            channelID={managedChannelID}
+            manualChannelOptions={channelOptions}
+            requireManualChannelSelect
+            showProcurementBatches={false}
+          />
         </AppSection>
       </AppSpin>
     </div>

--- a/web/src/pages/Channel/ChannelForm.jsx
+++ b/web/src/pages/Channel/ChannelForm.jsx
@@ -20,7 +20,6 @@ import {
   loadChannelProtocolOptions,
 } from '../../helpers/helper';
 import ChannelDetailEndpointsTab from './components/ChannelDetailEndpointsTab';
-import ChannelDetailBillingTab from './components/ChannelDetailBillingTab';
 import ChannelDetailModelsTab from './components/ChannelDetailModelsTab';
 import ChannelDetailOverviewTab from './components/ChannelDetailOverviewTab';
 import ChannelDetailPublishTab from './components/ChannelDetailPublishTab';
@@ -502,7 +501,6 @@ const DETAIL_TAB_KEYS = [
   'endpoints',
   'tests',
   'publish',
-  'billing',
 ];
 
 const normalizeDetailTab = (value) => {
@@ -2465,7 +2463,6 @@ const ChannelForm = ({ mode = 'auto' } = {}) => {
     isDetailMode && activeDetailTab === 'endpoints';
   const showDetailTestsTab = isDetailMode && activeDetailTab === 'tests';
   const showDetailPublishTab = isDetailMode && activeDetailTab === 'publish';
-  const showDetailBillingTab = isDetailMode && activeDetailTab === 'billing';
   const detailBasicReadonly = isDetailMode && !detailBasicEditing;
   const detailModelsEditing =
     isDetailMode && detailEditingModelKey.toString().trim() !== '';
@@ -2497,11 +2494,6 @@ const ChannelForm = ({ mode = 'auto' } = {}) => {
       label: t('channel.edit.detail_tabs.publish'),
       disabled: isAnyDetailSectionEditing && activeDetailTab !== 'publish',
     },
-    {
-      key: 'billing',
-      label: t('channel.edit.detail_tabs.billing'),
-      disabled: isAnyDetailSectionEditing && activeDetailTab !== 'billing',
-    },
   ];
   const detailBasicEditLocked =
     isDetailMode &&
@@ -2515,7 +2507,6 @@ const ChannelForm = ({ mode = 'auto' } = {}) => {
     isDetailMode && (detailBasicEditing || detailBillingEditing);
   const detailTestingReadonly = isDetailMode && isAnyDetailSectionEditing;
   const detailPublishReadonly = isDetailMode && isAnyDetailSectionEditing;
-  const detailBillingReadonly = isDetailMode && isAnyDetailSectionEditing;
   const inputReadonlyProps = detailBasicReadonly ? { readOnly: true } : {};
   const visibleChannelModels = useMemo(
     () => normalizeChannelModels(inputs.channel_models, inputs.protocol),
@@ -5336,17 +5327,6 @@ const ChannelForm = ({ mode = 'auto' } = {}) => {
   }, [channelId, hasChannelID, loadChannelById]);
 
   useEffect(() => {
-    if (!showDetailBillingTab) {
-      return;
-    }
-    const normalizedChannelId = (channelId || '').toString().trim();
-    if (normalizedChannelId === '') {
-      return;
-    }
-    refreshChannelBillingState(normalizedChannelId).then();
-  }, [channelId, refreshChannelBillingState, showDetailBillingTab]);
-
-  useEffect(() => {
     if (!isDetailMode || !channelId) {
       setChannelEndpoints([]);
       setChannelEndpointsError('');
@@ -6123,6 +6103,9 @@ const ChannelForm = ({ mode = 'auto' } = {}) => {
                 timestamp2string={timestamp2string}
                 billingProfile={channelBillingProfile}
                 billingAdapters={channelBillingAdapters}
+                billingSummary={channelBillingSummary}
+                billingLoading={channelBillingLoading}
+                billingError={channelBillingError}
                 detailBillingEditing={detailBillingEditing}
                 detailBillingDraft={detailBillingDraft}
                 billingSubmitting={channelBillingSubmitting}
@@ -6131,6 +6114,8 @@ const ChannelForm = ({ mode = 'auto' } = {}) => {
                 onUpdateBillingProfileDraft={updateBillingProfileDraft}
                 onCancelBillingProfileEdit={cancelDetailBillingEdit}
                 onSaveBillingProfile={saveDetailBillingProfile}
+                onRefreshBilling={refreshChannelBillingNow}
+                channelID={channelId}
               />
             )}
             {showStepTwo && inputs.protocol !== 'proxy' && (
@@ -6259,20 +6244,6 @@ const ChannelForm = ({ mode = 'auto' } = {}) => {
                 onUpdatePublish={updateChannelModelPublish}
                 publishMutatingModel={publishMutatingModel}
                 publishReadonly={detailPublishReadonly}
-              />
-            )}
-            {showDetailBillingTab && (
-              <ChannelDetailBillingTab
-                t={t}
-                billingSummary={channelBillingSummary}
-                billingLoading={channelBillingLoading}
-                billingError={channelBillingError}
-                billingReadonly={detailBillingReadonly}
-                billingSubmitting={channelBillingSubmitting}
-                onRefreshBilling={refreshChannelBillingNow}
-                timestamp2string={timestamp2string}
-                viewMode='account'
-                channelID={channelId}
               />
             )}
           </div>

--- a/web/src/pages/Channel/components/ChannelDetailBillingTab.jsx
+++ b/web/src/pages/Channel/components/ChannelDetailBillingTab.jsx
@@ -1,6 +1,7 @@
 import React, { useMemo, useState } from 'react';
 import { Link } from 'react-router-dom';
 import UnitDropdown from '../../../components/UnitDropdown';
+import { showInfo } from '../../../helpers';
 import {
   AppAlert,
   AppButton,
@@ -50,6 +51,7 @@ const toDateTimeLocalValue = (date) => {
 };
 
 const buildManualPurchaseRecord = () => ({
+  channel_id: '',
   purchase_at_input: toDateTimeLocalValue(new Date()),
   purchase_currency: 'CNY',
   purchase_amount: null,
@@ -245,45 +247,6 @@ const classifyEntitlementItem = (item, t) => {
   };
 };
 
-const summarizeEntitlementMode = (items, t) => {
-  const rows = Array.isArray(items) ? items : [];
-  const hasPlan = rows.some(
-    (row) => normalizeBillingValue(row?.resource_type) === 'plan'
-  );
-  const hasPeriodic = rows.some((row) => isPeriodicQuotaType(row?.quota_type));
-  const hasMetered = rows.some((row) => {
-    const resourceType = normalizeBillingValue(row?.resource_type);
-    const quotaType = normalizeBillingValue(row?.quota_type);
-    return (
-      resourceType === 'balance' ||
-      resourceType === 'credit' ||
-      quotaType === 'total'
-    );
-  });
-  if (hasPlan || hasPeriodic) {
-    return {
-      kind: 'package',
-      color: 'blue',
-      label: t('channel.edit.billing.mode_summary.package_title'),
-      description: t('channel.edit.billing.mode_summary.package_description'),
-    };
-  }
-  if (hasMetered) {
-    return {
-      kind: 'metered',
-      color: 'cyan',
-      label: t('channel.edit.billing.mode_summary.metered_title'),
-      description: t('channel.edit.billing.mode_summary.metered_description'),
-    };
-  }
-  return {
-    kind: 'unknown',
-    color: 'default',
-    label: t('channel.edit.billing.mode_summary.unknown_title'),
-    description: t('channel.edit.billing.mode_summary.unknown_description'),
-  };
-};
-
 const formatExpiresAtText = (item, timestamp2string, t) => {
   const expiresAt = Number(item?.expires_at || 0);
   if (expiresAt <= 0) {
@@ -403,9 +366,13 @@ const renderQuotaLabel = (value, row, t) => {
   );
 };
 
-const renderStatus = (row, t) => (
-  <AppTag color={statusColor(row)}>{formatItemStatusText(row, t)}</AppTag>
-);
+const renderStatus = (row, t) => {
+  const status = normalizeBillingValue(row?.status);
+  if (!status || status === 'depleted') {
+    return '-';
+  }
+  return <AppTag color={statusColor(row)}>{formatItemStatusText(row, t)}</AppTag>;
+};
 
 const formatNumberText = (value, digits = 6) => {
   const amount = Number(value || 0);
@@ -567,6 +534,7 @@ const normalizeManualValidityInput = (value, defaultTime, forceDefaultTime = fal
 };
 
 const buildManualPurchaseRecordFromSnapshot = (row) => ({
+  channel_id: (row?.channel_id || '').toString().trim(),
   purchase_at_input:
     toDateTimeLocalValueFromTimestamp(row?.purchase_at) ||
     buildManualPurchaseRecord().purchase_at_input,
@@ -616,6 +584,9 @@ const ChannelDetailBillingTab = ({
   timestamp2string,
   viewMode = 'account',
   channelID,
+  manualChannelOptions = [],
+  requireManualChannelSelect = false,
+  showProcurementBatches = true,
 }) => {
   const [manualPurchaseRecord, setManualPurchaseRecord] = useState(
     buildManualPurchaseRecord()
@@ -636,7 +607,7 @@ const ChannelDetailBillingTab = ({
     valid_until_input: false,
   });
   const [billingView, setBillingView] = useState(
-    viewMode === 'procurement' ? 'records' : 'upstream'
+    viewMode === 'procurement' ? 'records' : 'overview'
   );
 
   const purchaseRecords = useMemo(
@@ -659,7 +630,6 @@ const ChannelDetailBillingTab = ({
   const latestSnapshotMessage = (billingSummary?.latest_snapshot_message || '')
     .toString()
     .trim();
-  const entitlementModeSummary = summarizeEntitlementMode(quotaItems, t);
 
   const appendManualItem = () => {
     setManualItems((prev) => [...prev, buildManualQuotaItem()]);
@@ -716,7 +686,10 @@ const ChannelDetailBillingTab = ({
 
   const openCreateManualModal = () => {
     setEditingPurchaseRecord(null);
-    setManualPurchaseRecord(buildManualPurchaseRecord());
+    setManualPurchaseRecord({
+      ...buildManualPurchaseRecord(),
+      channel_id: (channelID || '').toString().trim(),
+    });
     setManualValidityTouched({
       valid_from_input: false,
       valid_until_input: false,
@@ -728,7 +701,11 @@ const ChannelDetailBillingTab = ({
 
   const openEditManualModal = (row) => {
     setEditingPurchaseRecord(row);
-    setManualPurchaseRecord(buildManualPurchaseRecordFromSnapshot(row));
+    setManualPurchaseRecord({
+      ...buildManualPurchaseRecordFromSnapshot(row),
+      channel_id:
+        (row?.channel_id || channelID || '').toString().trim(),
+    });
     setManualValidityTouched({
       valid_from_input: true,
       valid_until_input: true,
@@ -785,6 +762,13 @@ const ChannelDetailBillingTab = ({
   };
 
   const submitManualSnapshot = async () => {
+    const targetChannelID = (manualPurchaseRecord.channel_id || channelID || '')
+      .toString()
+      .trim();
+    if (requireManualChannelSelect && !targetChannelID) {
+      showInfo(t('channel.edit.billing.manual_channel_required'));
+      return;
+    }
     const purchaseAmount = Number(manualPurchaseRecord.purchase_amount || 0);
     const purchaseCurrency = (manualPurchaseRecord.purchase_currency || 'CNY')
       .toString()
@@ -797,6 +781,7 @@ const ChannelDetailBillingTab = ({
       ? purchaseAmount
       : Number(manualPurchaseRecord.purchase_cost_amount || 0);
     const saved = await onManualSnapshotUpdate({
+      channel_id: targetChannelID,
       id: editingPurchaseRecord?.id || '',
       purchase_at: toUnixTimestamp(manualPurchaseRecord.purchase_at_input),
       purchase_currency: purchaseCurrency,
@@ -870,6 +855,27 @@ const ChannelDetailBillingTab = ({
           </div>
         </div>
         <AppFormRow>
+          {requireManualChannelSelect ? (
+            <AppField label={t('channel.edit.billing.manual_channel')} required>
+              <AppSelect
+                className='router-section-input'
+                search
+                options={manualChannelOptions}
+                value={manualPurchaseRecord.channel_id}
+                placeholder={t('channel.edit.billing.manual_channel_placeholder')}
+                onChange={(e, { value }) =>
+                  updateManualPurchaseRecord({
+                    channel_id: (value || '').toString().trim(),
+                  })
+                }
+                disabled={
+                  billingReadonly ||
+                  billingSubmitting ||
+                  Boolean(editingPurchaseRecord?.id)
+                }
+              />
+            </AppField>
+          ) : null}
           <AppField label={t('channel.edit.billing.manual_purchase_at')} required>
             <AppInput
               className='router-section-input'
@@ -1279,59 +1285,36 @@ const ChannelDetailBillingTab = ({
   );
 
   return (
-    <AppDetailSection
-      title={t(viewMode === 'procurement' ? 'channel.edit.billing.procurement_title' : 'channel.edit.billing.title')}
-      titleTag='span'
-      bodyClassName='router-billing-page'
-    >
-      {viewMode === 'account' ? (
-        <div className='router-billing-workspace-toolbar'>
-          <strong>{t('channel.edit.billing.upstream_status_title')}</strong>
-          <Link to={`/admin/finance/procurement-cost${channelID ? `?channel_id=${encodeURIComponent(channelID)}` : ''}`}>
-            {t('channel.edit.billing.view_procurement')}
-          </Link>
-        </div>
-      ) : <div className='router-billing-workspace-toolbar'>
-        <AppSegmented
-          value={billingView}
-          onChange={(e, { value }) => setBillingView(value)}
-          options={[
-            { value: 'records', label: t('channel.edit.billing.snapshots_title') },
-            { value: 'batches', label: t('channel.edit.billing.procurement_title') },
-          ]}
-        />
-        {billingView === 'records' || billingView === 'batches' ? (
+    <div className='router-billing-page'>
+      {viewMode === 'procurement' ? <div className='router-billing-workspace-toolbar'>
+        {showProcurementBatches ? (
+          <AppSegmented
+            value={billingView}
+            onChange={(e, { value }) => setBillingView(value)}
+            options={[
+              { value: 'records', label: t('channel.edit.billing.snapshots_title') },
+              { value: 'batches', label: t('channel.edit.billing.procurement_title') },
+            ]}
+          />
+        ) : null}
+        {billingView === 'records' || (showProcurementBatches && billingView === 'batches') ? (
           <AppButton type='button' className='router-page-button' color='blue'
             disabled={billingReadonly || billingSubmitting}
             onClick={openCreateManualModal}>
             {t('channel.edit.billing.add_purchase_record')}
           </AppButton>
         ) : null}
-      </div>}
+      </div> : null}
       {viewMode === 'procurement' ? <AppAlert type='info' showIcon className='router-section-message' title={t('channel.edit.billing.structure_hint')} /> : null}
-      {billingView === 'upstream' && <div className='router-billing-upstream-view'>
-      <div className='router-billing-overview-strip'>
-        <div className='router-billing-overview-main'>
-          <AppTag color={entitlementModeSummary.color}>
-            {entitlementModeSummary.label}
-          </AppTag>
-          <span>{entitlementModeSummary.description}</span>
-        </div>
-        <div className='router-billing-overview-meta'>
-          <span>{t('channel.edit.billing.latest_snapshot_at')}</span>
-          <strong>
-            {billingSummary?.latest_snapshot_at
-              ? timestamp2string(billingSummary.latest_snapshot_at)
-              : '-'}
-          </strong>
-        </div>
-      </div>
-      <div>
+      {billingView === 'overview' && (
         <AppDetailSection
           title={t('channel.edit.billing.current_quotas_title')}
           titleTag='span'
           headerEnd={
             <div className='router-billing-quota-status-actions'>
+              <Link to={`/admin/finance/procurement-cost${channelID ? `?channel_id=${encodeURIComponent(channelID)}` : ''}`}>
+                {t('channel.edit.billing.view_procurement')}
+              </Link>
               <span className='router-billing-snapshot-time'>
                 {billingSummary?.latest_snapshot_at
                   ? timestamp2string(billingSummary.latest_snapshot_at)
@@ -1427,8 +1410,7 @@ const ChannelDetailBillingTab = ({
             }}
           />
         </AppDetailSection>
-      </div>
-      </div>}
+      )}
       {billingView === 'records' && (
         <AppDetailSection
           className='router-billing-management-section'
@@ -1558,7 +1540,7 @@ const ChannelDetailBillingTab = ({
           />
         </AppDetailSection>
       )}
-      {billingView === 'batches' && (
+      {showProcurementBatches && billingView === 'batches' && (
         <AppDetailSection className='router-billing-management-section'
           title={t('channel.edit.billing.procurement_title')} titleTag='span'>
           <div className='router-billing-subsection-header'>
@@ -1856,7 +1838,7 @@ const ChannelDetailBillingTab = ({
           </div>
         )}
       </div>
-    </AppDetailSection>
+    </div>
   );
 };
 

--- a/web/src/pages/Channel/components/ChannelDetailOverviewTab.jsx
+++ b/web/src/pages/Channel/components/ChannelDetailOverviewTab.jsx
@@ -7,6 +7,7 @@ import {
   AppInput,
   AppSelect,
 } from '../../../router-ui';
+import ChannelDetailBillingTab from './ChannelDetailBillingTab';
 
 const normalizeBillingSourceValue = (source) => {
   const normalizedSource = (source || '').toString().trim().toLowerCase();
@@ -148,6 +149,9 @@ const ChannelDetailOverviewTab = ({
   timestamp2string,
   billingProfile,
   billingAdapters,
+  billingSummary,
+  billingLoading,
+  billingError,
   detailBillingEditing,
   detailBillingDraft,
   billingSubmitting,
@@ -156,6 +160,8 @@ const ChannelDetailOverviewTab = ({
   onUpdateBillingProfileDraft,
   onCancelBillingProfileEdit,
   onSaveBillingProfile,
+  onRefreshBilling,
+  channelID,
 }) => {
   const billingReadonly = !detailBillingEditing || billingSubmitting;
   const selectedBillingSource = detailBillingEditing
@@ -402,6 +408,18 @@ const ChannelDetailOverviewTab = ({
           {t('channel.edit.billing.credential_hint')}
         </div>
       </AppDetailSection>
+      <ChannelDetailBillingTab
+        t={t}
+        billingSummary={billingSummary}
+        billingLoading={billingLoading}
+        billingError={billingError}
+        billingReadonly={!detailBillingEditing}
+        billingSubmitting={billingSubmitting}
+        onRefreshBilling={onRefreshBilling}
+        timestamp2string={timestamp2string}
+        viewMode='account'
+        channelID={channelID}
+      />
     </>
   );
 };


### PR DESCRIPTION
## Summary
- Move channel billing entitlement status into the Overview tab and remove the standalone Billing tab
- Keep Router billing integration scoped to the billing service instead of vendor upstream fields
- Simplify finance procurement management by keeping purchase records primary and selecting the channel in the add flow

## Tests
- `cd web && npm run build`
- `go test ./internal/admin/controller/channel`
