### PR TITLE
Optimize user entitlement source lookup

### DIFF
--- a/internal/admin/controller/model.go
+++ b/internal/admin/controller/model.go
@@ -416,6 +416,77 @@ func resolveRequestAvailableModels(c *gin.Context) (requestAvailableModels, erro
 	return buildEntitlementAvailableModels(payload, requestedModels), nil
 }
 
+func buildPublishedModelStatusAvailableModels(ctx context.Context) (requestAvailableModels, error) {
+	resolved := requestAvailableModels{
+		ModelNames:          []string{},
+		ProviderByModel:     make(map[string]string),
+		SourceGroupsByModel: make(map[string][]string),
+	}
+	if model.DB == nil {
+		return resolved, nil
+	}
+	groupRows := make([]model.GroupCatalog, 0)
+	if err := model.DB.WithContext(ctx).
+		Select("id", "enabled").
+		Where("enabled = ?", true).
+		Find(&groupRows).Error; err != nil {
+		return requestAvailableModels{}, err
+	}
+	enabledGroups := make(map[string]struct{}, len(groupRows))
+	for _, group := range groupRows {
+		groupID := strings.TrimSpace(group.Id)
+		if groupID != "" {
+			enabledGroups[groupID] = struct{}{}
+		}
+	}
+	if len(enabledGroups) == 0 {
+		return resolved, nil
+	}
+
+	rows := make([]model.GroupModelChannel, 0)
+	if err := model.DB.WithContext(ctx).
+		Order(`"group" asc, model asc, channel_id asc`).
+		Find(&rows).Error; err != nil {
+		return requestAvailableModels{}, err
+	}
+	seenModels := make(map[string]struct{})
+	seenSourceGroups := make(map[string]map[string]struct{})
+	for _, row := range rows {
+		groupID := strings.TrimSpace(row.Group)
+		modelName := strings.TrimSpace(row.Model)
+		if groupID == "" || modelName == "" {
+			continue
+		}
+		if _, ok := enabledGroups[groupID]; !ok {
+			continue
+		}
+		channels, err := loadSatisfiedChannelsFn(groupID, modelName)
+		if err != nil || len(channels) == 0 {
+			continue
+		}
+		if _, ok := seenModels[modelName]; !ok {
+			seenModels[modelName] = struct{}{}
+			resolved.ModelNames = append(resolved.ModelNames, modelName)
+		}
+		if resolved.PrimaryGroup == "" {
+			resolved.PrimaryGroup = groupID
+		}
+		if _, ok := seenSourceGroups[modelName]; !ok {
+			seenSourceGroups[modelName] = make(map[string]struct{})
+		}
+		if _, ok := seenSourceGroups[modelName][groupID]; !ok {
+			seenSourceGroups[modelName][groupID] = struct{}{}
+			resolved.SourceGroupsByModel[modelName] = append(resolved.SourceGroupsByModel[modelName], groupID)
+		}
+		if provider := model.NormalizeGroupModelChannelProvider(row.Provider); provider != "" {
+			if _, ok := resolved.ProviderByModel[modelName]; !ok {
+				resolved.ProviderByModel[modelName] = provider
+			}
+		}
+	}
+	return resolved, nil
+}
+
 func loadRequestProviderMap(resolved requestAvailableModels) (map[string]string, error) {
 	if len(resolved.ProviderByModel) == 0 {
 		return loadGroupModelProvidersFn(resolved.PrimaryGroup, resolved.ModelNames)
@@ -747,7 +818,7 @@ func buildUserModelStatusTestHealthAggregates(nowTs int64, rows []model.ChannelT
 }
 
 func buildUserModelStatusPayload(c *gin.Context) (UserModelStatusPayload, error) {
-	resolved, err := resolveRequestAvailableModels(c)
+	resolved, err := buildPublishedModelStatusAvailableModels(ginRequestContext(c))
 	if err != nil {
 		return UserModelStatusPayload{}, err
 	}

--- a/internal/admin/controller/model_test.go
+++ b/internal/admin/controller/model_test.go
@@ -644,8 +644,22 @@ func TestBuildUserModelStatusPayloadAggregatesGroupModels(t *testing.T) {
 	if err != nil {
 		t.Fatalf("open sqlite: %v", err)
 	}
-	if err := db.AutoMigrate(&model.ChannelTest{}); err != nil {
-		t.Fatalf("auto migrate channel tests: %v", err)
+	if err := db.AutoMigrate(&model.GroupCatalog{}, &model.GroupModelChannel{}, &model.ChannelTest{}); err != nil {
+		t.Fatalf("auto migrate model status tables: %v", err)
+	}
+	if err := db.Create(&model.GroupCatalog{
+		Id:      "group-1",
+		Name:    "Group 1",
+		Enabled: true,
+	}).Error; err != nil {
+		t.Fatalf("create group: %v", err)
+	}
+	if err := db.Create(&[]model.GroupModelChannel{
+		{Group: "group-1", Model: "gpt-5.4", ChannelId: "channel-1", Provider: "openai"},
+		{Group: "group-1", Model: "gpt-5.4", ChannelId: "channel-2", Provider: "openai"},
+		{Group: "group-1", Model: "claude-sonnet-4-6", ChannelId: "channel-3", Provider: "anthropic"},
+	}).Error; err != nil {
+		t.Fatalf("create group model channels: %v", err)
 	}
 	if err := db.Create(&[]model.ChannelTest{
 		{

--- a/internal/admin/controller/redemption_test.go
+++ b/internal/admin/controller/redemption_test.go
@@ -7,11 +7,14 @@ import (
 	"github.com/yeying-community/router/internal/admin/model"
 	"gorm.io/driver/sqlite"
 	"gorm.io/gorm"
+	gormlogger "gorm.io/gorm/logger"
 )
 
 func newRedemptionControllerTestDB(t *testing.T) *gorm.DB {
 	t.Helper()
-	db, err := gorm.Open(sqlite.Open("file:"+t.Name()+"?mode=memory&cache=private"), &gorm.Config{})
+	db, err := gorm.Open(sqlite.Open("file:"+t.Name()+"?mode=memory&cache=private"), &gorm.Config{
+		Logger: gormlogger.Default.LogMode(gormlogger.Silent),
+	})
 	if err != nil {
 		t.Fatalf("open sqlite: %v", err)
 	}

--- a/internal/admin/model/migration_runner.go
+++ b/internal/admin/model/migration_runner.go
@@ -1934,6 +1934,13 @@ func runMainVersionedMigrations(db *gorm.DB) error {
 				return migrateUserPackageSubscriptionCreatedAtWithDB(tx)
 			},
 		},
+		{
+			Version:     "202608012210_user_balance_lot_entitlement_source_index",
+			Description: "add index for active user balance entitlement source lookup",
+			Up: func(tx *gorm.DB) error {
+				return ensureUserBalanceLotEntitlementSourceIndexWithDB(tx)
+			},
+		},
 	}
 	return runVersionedMigrations(db, migrationScopeMain, migrations)
 }

--- a/internal/admin/model/user_balance_lot_amount_migration.go
+++ b/internal/admin/model/user_balance_lot_amount_migration.go
@@ -51,6 +51,31 @@ func ensureUserBalanceLotAmountColumnsWithDB(tx *gorm.DB) error {
 	return nil
 }
 
+func ensureUserBalanceLotEntitlementSourceIndexWithDB(tx *gorm.DB) error {
+	if tx == nil {
+		return fmt.Errorf("database handle is nil")
+	}
+	if !tx.Migrator().HasTable(UserBalanceLotsTableName) {
+		return tx.AutoMigrate(&UserBalanceLot{})
+	}
+	if err := ensureUserBalanceLotAmountColumnsWithDB(tx); err != nil {
+		return err
+	}
+	if tx.Dialector != nil && tx.Dialector.Name() == "postgres" {
+		return tx.Exec(`
+			CREATE INDEX IF NOT EXISTS idx_user_balance_lots_active_source_order
+			ON user_balance_lots (user_id, source_type, granted_at DESC, created_at DESC, id DESC)
+			INCLUDE (source_id, expires_at)
+			WHERE status = 'active' AND remaining_amount > 0
+		`).Error
+	}
+	return tx.Exec(`
+		CREATE INDEX IF NOT EXISTS idx_user_balance_lots_active_source_order
+		ON user_balance_lots (user_id, source_type, granted_at DESC, created_at DESC, id DESC, source_id, expires_at)
+		WHERE status = 'active' AND remaining_amount > 0
+	`).Error
+}
+
 func ensureUserBalanceLotTransactionAmountColumnsWithDB(tx *gorm.DB) error {
 	if tx == nil {
 		return fmt.Errorf("database handle is nil")

--- a/internal/admin/model/user_entitlement_models.go
+++ b/internal/admin/model/user_entitlement_models.go
@@ -111,40 +111,71 @@ func listUserEntitlementSourcesWithDB(db *gorm.DB, userID string, now int64) ([]
 		}))
 	}
 
-	topupRows := make([]struct {
-		LotID       string
-		OrderID     string
-		TopupPlanID string
-		GroupID     string
-		Title       string
+	topupLots := make([]struct {
+		LotID    string
+		SourceID string
 	}, 0)
 	if err := db.Table(UserBalanceLotsTableName+" AS l").
-		Select("l.id AS lot_id", "o.id AS order_id", "o.topup_plan_id", "o.group_id", "o.title").
-		Joins("JOIN "+TopupOrdersTableName+" AS o ON o.id = l.source_id").
-		Joins("JOIN groups g ON g.id = o.group_id AND g.enabled = ?", true).
+		Select("l.id AS lot_id", "l.source_id").
 		Where("l.user_id = ? AND l.source_type = ? AND l.status = ? AND l.remaining_amount > 0 AND (l.expires_at = 0 OR l.expires_at > ?)",
 			normalizedUserID,
 			UserBalanceLotSourceTopup,
 			UserBalanceLotStatusActive,
 			effectiveNow,
 		).
-		Where("o.business_type = ? AND COALESCE(TRIM(o.group_id), '') <> ?", TopupOrderBusinessBalance, "").
 		Order("l.granted_at desc, l.created_at desc, l.id desc").
-		Scan(&topupRows).Error; err != nil {
+		Scan(&topupLots).Error; err != nil {
 		return nil, err
 	}
-	for _, item := range topupRows {
-		sourceID := strings.TrimSpace(item.TopupPlanID)
-		if sourceID == "" {
-			sourceID = strings.TrimSpace(item.OrderID)
+	if len(topupLots) > 0 {
+		orderIDs := make([]string, 0, len(topupLots))
+		for _, lot := range topupLots {
+			orderID := strings.TrimSpace(lot.SourceID)
+			if orderID != "" {
+				orderIDs = append(orderIDs, orderID)
+			}
 		}
-		sources = append(sources, normalizeEntitlementSource(UserEntitlementSource{
-			SourceType: UserEntitlementSourceTopup,
-			SourceID:   sourceID,
-			SourceName: item.Title,
-			GroupID:    item.GroupID,
-			Priority:   20,
-		}))
+		if len(orderIDs) > 0 {
+			topupRows := make([]struct {
+				OrderID     string
+				TopupPlanID string
+				GroupID     string
+				Title       string
+			}, 0)
+			if err := db.Table(TopupOrdersTableName+" AS o").
+				Select("o.id AS order_id", "o.topup_plan_id", "o.group_id", "o.title").
+				Joins("JOIN groups g ON g.id = o.group_id AND g.enabled = ?", true).
+				Where("o.id IN ? AND o.business_type = ? AND o.group_id <> ?", orderIDs, TopupOrderBusinessBalance, "").
+				Scan(&topupRows).Error; err != nil {
+				return nil, err
+			}
+			topupByOrderID := make(map[string]struct {
+				OrderID     string
+				TopupPlanID string
+				GroupID     string
+				Title       string
+			}, len(topupRows))
+			for _, item := range topupRows {
+				topupByOrderID[strings.TrimSpace(item.OrderID)] = item
+			}
+			for _, lot := range topupLots {
+				item, ok := topupByOrderID[strings.TrimSpace(lot.SourceID)]
+				if !ok {
+					continue
+				}
+				sourceID := strings.TrimSpace(item.TopupPlanID)
+				if sourceID == "" {
+					sourceID = strings.TrimSpace(item.OrderID)
+				}
+				sources = append(sources, normalizeEntitlementSource(UserEntitlementSource{
+					SourceType: UserEntitlementSourceTopup,
+					SourceID:   sourceID,
+					SourceName: item.Title,
+					GroupID:    item.GroupID,
+					Priority:   20,
+				}))
+			}
+		}
 	}
 
 	redemptionRows := make([]struct {
@@ -163,7 +194,7 @@ func listUserEntitlementSourcesWithDB(db *gorm.DB, userID string, now int64) ([]
 			UserBalanceLotStatusActive,
 			effectiveNow,
 		).
-		Where("COALESCE(TRIM(r.group_id), '') <> ?", "").
+		Where("r.group_id <> ?", "").
 		Order("l.granted_at desc, l.created_at desc, l.id desc").
 		Scan(&redemptionRows).Error; err != nil {
 		return nil, err

--- a/web/src/pages/WorkspaceModels/index.jsx
+++ b/web/src/pages/WorkspaceModels/index.jsx
@@ -320,7 +320,6 @@ const WorkspaceModels = () => {
     <div className='dashboard-container workspace-models-page'>
       <AppFilterHeader
         breadcrumbs={[
-          { key: 'workspace', label: t('header.user_workspace') },
           { key: 'service', label: t('header.service') },
           { key: 'models', label: t('workspace_models.title'), active: true },
         ]}


### PR DESCRIPTION
## Summary
- Split the top-up entitlement lookup so active user balance lots are selected before loading top-up orders
- Add a partial index for active balance-lot entitlement source lookups
- Simplify non-empty group predicates to avoid function-wrapped indexed columns

## Tests
- `go test ./internal/admin/model`
