### PR TITLE
Normalize public model API routes

### DIFF
--- a/docs/openapi/router.openapi.yaml
+++ b/docs/openapi/router.openapi.yaml
@@ -299,13 +299,13 @@ paths:
         - $ref: "#/components/parameters/IDPath"
       responses:
         "200": { $ref: "#/components/responses/APIResponse" }
-  /api/v1/public/user/available_models:
+  /api/v1/public/user/models/available:
     get:
       tags: [Public User]
       summary: List models available to current user
       responses:
         "200": { $ref: "#/components/responses/APIResponse" }
-  /api/v1/public/user/model_status:
+  /api/v1/public/model/status:
     get:
       tags: [Public User]
       summary: List platform model service status

--- a/internal/transport/http/router/api.go
+++ b/internal/transport/http/router/api.go
@@ -55,6 +55,7 @@ func SetApiRouter(engine *gin.Engine) {
 		publicRouter.GET("/about", admin.GetAbout)
 		publicRouter.GET("/home_page_content", admin.GetHomePageContent)
 		publicRouter.POST("/topup/callback", admin.ProcessTopupCallback)
+		publicRouter.GET("/model/status", middleware.UserAuth(), admin.GetUserModelStatus)
 
 		// 仅保留密码找回，无额外人机验证
 		publicRouter.GET("/reset_password", middleware.CriticalRateLimit(), admin.SendPasswordResetEmail)
@@ -85,8 +86,7 @@ func SetApiRouter(engine *gin.Engine) {
 				publicSelfRoute.GET("/quota/overview", user.GetCurrentUserQuotaOverview)
 				publicSelfRoute.GET("/quota/cards", user.GetCurrentUserQuotaCards)
 				publicSelfRoute.GET("/quota/cards/:kind/:id", user.GetCurrentUserQuotaCard)
-				publicSelfRoute.GET("/available_models", admin.GetUserAvailableModels)
-				publicSelfRoute.GET("/model_status", admin.GetUserModelStatus)
+				publicSelfRoute.GET("/models/available", admin.GetUserAvailableModels)
 				publicSelfRoute.GET("/tasks/options", task.GetCurrentUserTaskFilterOptions)
 				publicSelfRoute.GET("/tasks", task.GetCurrentUserTasks)
 				publicSelfRoute.GET("/tasks/:id", task.GetCurrentUserTask)

--- a/web/src/components/RedemptionsTable.jsx
+++ b/web/src/components/RedemptionsTable.jsx
@@ -8,6 +8,7 @@ import {
   showSuccess,
   showWarning,
   hasLoadedPagedRows,
+  timestamp2string,
   writePagedRows,
 } from '../helpers';
 

--- a/web/src/pages/Token/EditToken.jsx
+++ b/web/src/pages/Token/EditToken.jsx
@@ -506,7 +506,7 @@ const EditToken = () => {
 
   const loadAvailableModels = useCallback(async () => {
     try {
-      let res = await API.get(`/api/v1/public/user/available_models`);
+      let res = await API.get(`/api/v1/public/user/models/available`);
       const { success, message, data } = res.data || {};
       if (success && data) {
         const itemByModel = new Map(

--- a/web/src/pages/WorkspaceModels/index.jsx
+++ b/web/src/pages/WorkspaceModels/index.jsx
@@ -226,7 +226,7 @@ const WorkspaceModels = () => {
   const loadData = useCallback(async () => {
     setLoading(true);
     try {
-      const res = await API.get('/api/v1/public/user/model_status');
+      const res = await API.get('/api/v1/public/model/status');
       if (res.data?.success) {
         setPayload(normalizePayload(res.data.data || {}));
       } else {
@@ -485,7 +485,6 @@ const WorkspaceModels = () => {
                               title={title}
                               placement='top'
                               color='#ffffff'
-                              overlayClassName='workspace-model-health-tooltip-popup'
                               classNames={{ root: 'workspace-model-health-tooltip-popup' }}
                             >
                               <span


### PR DESCRIPTION
## Summary
- move platform model status to `/api/v1/public/model/status`
- move user-scoped available models to `/api/v1/public/user/models/available`
- update frontend callers and OpenAPI paths
- fix the missing `timestamp2string` import in the redemption table
- replace the deprecated Tooltip `overlayClassName` prop

## Verification
- `go test ./internal/transport/http/router ./internal/admin/controller`
- `npm run build`
- `git diff --check`