### PR TITLE
fix: preserve runtime endpoint recovery state

### DIFF
--- a/internal/admin/controller/channel/async_task.go
+++ b/internal/admin/controller/channel/async_task.go
@@ -344,6 +344,10 @@ func EnqueueRuntimeDisabledCapabilityRecoveryTests(limit int) (int, error) {
 		}
 		created, err := EnqueueChannelModelEndpointRecoveryTest(row.ChannelId, row.Model, row.Endpoint, "")
 		if err != nil {
+			if errors.Is(err, gorm.ErrRecordNotFound) {
+				logSkippedRuntimeCapabilityRecovery(row.ChannelId, row.Model, row.Endpoint, err)
+				continue
+			}
 			return createdCount, err
 		}
 		if created {
@@ -365,6 +369,10 @@ func EnqueueRuntimeDisabledCapabilityRecoveryTests(limit int) (int, error) {
 		}
 		created, err := EnqueueChannelModelEndpointRecoveryTest(row.ChannelId, row.Model, row.Endpoint, "")
 		if err != nil {
+			if errors.Is(err, gorm.ErrRecordNotFound) {
+				logSkippedRuntimeCapabilityRecovery(row.ChannelId, row.Model, row.Endpoint, err)
+				continue
+			}
 			return createdCount, err
 		}
 		if created {
@@ -373,6 +381,16 @@ func EnqueueRuntimeDisabledCapabilityRecoveryTests(limit int) (int, error) {
 		seen[key] = struct{}{}
 	}
 	return createdCount, nil
+}
+
+func logSkippedRuntimeCapabilityRecovery(channelID string, modelID string, endpoint string, err error) {
+	logger.Warn(context.Background(), fmt.Sprintf(
+		"[async-task] runtime_capability_recovery_skipped channel_id=%q model=%q endpoint=%q error=%q",
+		strings.TrimSpace(channelID),
+		strings.TrimSpace(modelID),
+		model.NormalizeRequestedChannelModelEndpoint(endpoint),
+		err.Error(),
+	))
 }
 
 func validateChannelModelTestEndpointAgainstProvider(row model.ChannelModel, endpoint string) error {

--- a/internal/admin/controller/channel/endpoint.go
+++ b/internal/admin/controller/channel/endpoint.go
@@ -334,29 +334,40 @@ func UpdateChannelEndpoint(c *gin.Context) {
 
 func mergeUpdatedChannelEndpointRows(rows []model.ChannelModelEndpoint, updated model.ChannelModelEndpoint) []model.ChannelModelEndpoint {
 	normalizedUpdated := model.ChannelModelEndpoint{
-		ChannelId: strings.TrimSpace(updated.ChannelId),
-		Model:     strings.TrimSpace(updated.Model),
-		Endpoint:  model.NormalizeRequestedChannelModelEndpoint(updated.Endpoint),
-		BaseURL:   strings.TrimSpace(updated.BaseURL),
-		Enabled:   updated.Enabled,
-		UpdatedAt: updated.UpdatedAt,
+		ChannelId:      strings.TrimSpace(updated.ChannelId),
+		Model:          strings.TrimSpace(updated.Model),
+		Endpoint:       model.NormalizeRequestedChannelModelEndpoint(updated.Endpoint),
+		BaseURL:        strings.TrimSpace(updated.BaseURL),
+		Enabled:        updated.Enabled,
+		UpdatedAt:      updated.UpdatedAt,
+		DisabledReason: strings.TrimSpace(updated.DisabledReason),
+		DisabledAt:     updated.DisabledAt,
+		DisabledBy:     strings.TrimSpace(updated.DisabledBy),
 	}
 	result := make([]model.ChannelModelEndpoint, 0, len(rows)+1)
 	replaced := false
 	for _, row := range rows {
 		normalizedRow := model.ChannelModelEndpoint{
-			ChannelId: strings.TrimSpace(row.ChannelId),
-			Model:     strings.TrimSpace(row.Model),
-			Endpoint:  model.NormalizeRequestedChannelModelEndpoint(row.Endpoint),
-			BaseURL:   strings.TrimSpace(row.BaseURL),
-			Enabled:   row.Enabled,
-			UpdatedAt: row.UpdatedAt,
+			ChannelId:      strings.TrimSpace(row.ChannelId),
+			Model:          strings.TrimSpace(row.Model),
+			Endpoint:       model.NormalizeRequestedChannelModelEndpoint(row.Endpoint),
+			BaseURL:        strings.TrimSpace(row.BaseURL),
+			Enabled:        row.Enabled,
+			UpdatedAt:      row.UpdatedAt,
+			DisabledReason: strings.TrimSpace(row.DisabledReason),
+			DisabledAt:     row.DisabledAt,
+			DisabledBy:     strings.TrimSpace(row.DisabledBy),
 		}
 		if normalizedRow.ChannelId == normalizedUpdated.ChannelId &&
 			normalizedRow.Model == normalizedUpdated.Model &&
 			normalizedRow.Endpoint == normalizedUpdated.Endpoint {
 			normalizedRow.BaseURL = normalizedUpdated.BaseURL
 			normalizedRow.Enabled = normalizedUpdated.Enabled
+			if normalizedRow.Enabled {
+				normalizedRow.DisabledReason = ""
+				normalizedRow.DisabledAt = 0
+				normalizedRow.DisabledBy = ""
+			}
 			replaced = true
 		}
 		if normalizedRow.ChannelId == "" || normalizedRow.Model == "" || normalizedRow.Endpoint == "" {

--- a/internal/admin/controller/channel/endpoint_test.go
+++ b/internal/admin/controller/channel/endpoint_test.go
@@ -126,6 +126,44 @@ func TestUpdateChannelEndpointAllowsEnableWithoutTestResult(t *testing.T) {
 	}
 }
 
+func TestMergeUpdatedChannelEndpointRowsPreservesRuntimeDisableMetadata(t *testing.T) {
+	rows := []model.ChannelModelEndpoint{
+		{
+			ChannelId:      "channel-1",
+			Model:          "gpt-5.5",
+			Endpoint:       model.ChannelModelEndpointResponses,
+			Enabled:        false,
+			DisabledReason: "upstream quota exhausted",
+			DisabledAt:     123,
+			DisabledBy:     "runtime",
+		},
+		{
+			ChannelId: "channel-1",
+			Model:     "gpt-5.6-sol",
+			Endpoint:  model.ChannelModelEndpointResponses,
+			Enabled:   false,
+		},
+	}
+
+	merged := mergeUpdatedChannelEndpointRows(rows, model.ChannelModelEndpoint{
+		ChannelId: "channel-1",
+		Model:     "gpt-5.6-sol",
+		Endpoint:  model.ChannelModelEndpointResponses,
+		Enabled:   true,
+	})
+	if len(merged) != 2 {
+		t.Fatalf("merged rows len=%d, want 2", len(merged))
+	}
+	preserved := merged[0]
+	if preserved.Enabled || preserved.DisabledReason != "upstream quota exhausted" || preserved.DisabledAt != 123 || preserved.DisabledBy != "runtime" {
+		t.Fatalf("runtime-disabled endpoint metadata was not preserved: %+v", preserved)
+	}
+	updated := merged[1]
+	if !updated.Enabled || updated.DisabledReason != "" || updated.DisabledAt != 0 || updated.DisabledBy != "" {
+		t.Fatalf("enabled endpoint retained disabled metadata: %+v", updated)
+	}
+}
+
 func TestGetChannelEndpointsDoesNotShowLooseUpstreamModelSuccess(t *testing.T) {
 	gin.SetMode(gin.TestMode)
 	db := newChannelEndpointControllerTestDB(t)


### PR DESCRIPTION
## Summary
- preserve runtime disable metadata when updating another channel endpoint
- skip orphaned recovery records instead of aborting the entire recovery scan
- add regression coverage for endpoint metadata preservation

## Tests
- go test ./internal/admin/controller/channel
- go test ./internal/admin/model -run 'ChannelModelEndpoint|DisabledChannel'