### PR TITLE
fix: isolate stateful responses sessions

### DIFF
--- a/common/ctxkey/key.go
+++ b/common/ctxkey/key.go
@@ -25,6 +25,7 @@ const (
 	BaseURL                     = "base_url"
 	AvailableModels             = "available_models"
 	ResponsesPreviousResponseID = "responses_previous_response_id"
+	ResponsesItemIDs            = "responses_item_ids"
 	ResponsesStatefulRequest    = "responses_stateful_request"
 	KeyRequestBody              = "key_request_body"
 	UpstreamURL                 = "upstream_url"

--- a/docs/Responses有状态会话兼容性.md
+++ b/docs/Responses有状态会话兼容性.md
@@ -1,0 +1,80 @@
+# Responses 有状态会话兼容性
+
+## 适用范围
+
+本文说明 Codex 等客户端调用 `/v1/responses` 时，为什么不能在不同上游账号之间任意切换，以及遇到历史 item ID 不兼容时的处理方式。
+
+## 问题表现
+
+上游可能返回类似错误：
+
+```text
+Invalid 'input .id': 'fc_...'. Expected an ID that begins with 'ctc'.
+```
+
+其中 `fc_...` 通常是客户端历史中的 `function_call` item ID，`ctc...` 是某些上游会话系统要求的本地 item ID 前缀。
+
+## 根因
+
+Responses 请求可能携带以下状态：
+
+- `previous_response_id`
+- `function_call`
+- `function_call_output`
+- 历史 `input` item ID
+
+这些状态不一定能被另一个上游账号或会话池识别。典型链路是：
+
+1. Codex 会话先从上游 A 获得 `fc_...` item。
+2. 上游 A 暂时不可用，Router 选择上游 B。
+3. Codex 继续发送原会话历史。
+4. 上游 B 只接受自己的 `ctc...` item，于是返回 400。
+
+item ID 不能通过字符串替换解决，因为 ID 同时对应上游保存的会话状态。
+
+## Router 行为
+
+Router 对带状态的 Responses 请求默认不做普通渠道 fallback，以避免：
+
+- `previous_response_id` 在新渠道不存在；
+- 工具调用上下文丢失；
+- 工具被重复执行；
+- 请求在多个账号之间产生不可预测的状态。
+
+对于上游明确返回 item ID 前缀不兼容的 400，Router 会归一化为：
+
+```json
+{
+  "error": {
+    "type": "state_incompatible_error",
+    "code": "state_incompatible",
+    "message": "当前 Responses 会话与所选上游不兼容，请新建会话后重试"
+  }
+}
+```
+
+这不是渠道余额不足，也不会因此全局禁用渠道或模型端点。
+
+## 状态会话隔离
+
+Router 会为上游返回的 Response ID 和 Responses item ID 建立短期渠道绑定，默认保存 6 小时；启用 Redis 时使用 Redis 共享绑定，未启用 Redis 时使用当前进程内存。
+
+后续请求携带 `previous_response_id` 或历史 item `id` 时：
+
+1. 优先查找原渠道。
+2. 原渠道仍可承载当前模型和端点时，固定使用原渠道，不参与普通优先级随机选择。
+3. 如果同一请求中的状态 ID 分别绑定到多个渠道，Router 拒绝路由并要求新建会话，不会把会话继续发送到任意一个渠道。
+4. 没有可识别绑定的旧历史请求仍按普通规则选择渠道，但一旦上游返回 ID 前缀不兼容，客户端应新建会话。
+
+绑定的是渠道级状态，不代表不同渠道之间可以共享上游会话；渠道内如果还有多个上游账号，会话池仍应由渠道供应商保证一致性。
+
+## 排查和运维建议
+
+1. 用户端新建 Codex 会话，不要继续重放已经产生不兼容 ID 的历史会话。
+2. 尽量让一个 Responses 会话固定使用同一渠道和同一上游账号池。
+3. 看到 `state_incompatible` 时，优先检查近期是否发生渠道切换、上游账号切换或上游会话重置。
+4. 不要把 `fc_` 直接改成 `ctc`，也不要仅凭这个错误自动摘除整个渠道。
+
+## 后续演进
+
+如果未来要支持有状态请求自动切换渠道，需要建立完整的会话绑定和 item ID 映射，并验证工具调用状态；仅修改请求中的 ID 前缀是不安全的。

--- a/internal/admin/controller/relay.go
+++ b/internal/admin/controller/relay.go
@@ -354,6 +354,13 @@ func normalizeFinalRelayError(err *model.ErrorWithStatusCode) {
 	if err == nil {
 		return
 	}
+	if isResponsesStateIncompatibleError(err) {
+		err.StatusCode = http.StatusBadRequest
+		err.Error.Type = "state_incompatible_error"
+		err.Error.Code = "state_incompatible"
+		err.Error.Message = "当前 Responses 会话与所选上游不兼容，请新建会话后重试"
+		return
+	}
 	if isLocalQuotaRelayError(err) {
 		return
 	}
@@ -372,6 +379,18 @@ func normalizeFinalRelayError(err *model.ErrorWithStatusCode) {
 	}
 	err.StatusCode = http.StatusServiceUnavailable
 	err.Error.Message = "当前分组可用上游暂时不可用，请稍后再试"
+}
+
+func isResponsesStateIncompatibleError(err *model.ErrorWithStatusCode) bool {
+	if err == nil {
+		return false
+	}
+	message := strings.ToLower(strings.TrimSpace(err.Error.Message))
+	if err.StatusCode != http.StatusBadRequest || message == "" {
+		return false
+	}
+	return strings.Contains(message, "invalid 'input .id'") &&
+		strings.Contains(message, "expected an id that begins with")
 }
 
 func isLocalQuotaRelayError(err *model.ErrorWithStatusCode) bool {

--- a/internal/admin/controller/relay_status_test.go
+++ b/internal/admin/controller/relay_status_test.go
@@ -36,6 +36,29 @@ func TestNormalizeFinalRelayErrorForTransientUpstream429(t *testing.T) {
 	}
 }
 
+func TestNormalizeFinalRelayErrorForResponsesStateIncompatibleID(t *testing.T) {
+	err := &relaymodel.ErrorWithStatusCode{
+		StatusCode: http.StatusBadRequest,
+		Error: relaymodel.Error{
+			Message: "Invalid 'input .id': 'fc_abc'. Expected an ID that begins with 'ctc'.",
+			Type:    "invalid_request_error",
+			Code:    "invalid_request_error",
+		},
+	}
+
+	normalizeFinalRelayError(err)
+
+	if err.StatusCode != http.StatusBadRequest {
+		t.Fatalf("status=%d, want %d", err.StatusCode, http.StatusBadRequest)
+	}
+	if err.Type != "state_incompatible_error" || errorCodeString(err.Code) != "state_incompatible" {
+		t.Fatalf("type/code=%s/%s, want state_incompatible_error/state_incompatible", err.Type, errorCodeString(err.Code))
+	}
+	if err.Message != "当前 Responses 会话与所选上游不兼容，请新建会话后重试" {
+		t.Fatalf("message=%q", err.Message)
+	}
+}
+
 func TestNormalizeFinalRelayErrorForTransientDoRequestFailed(t *testing.T) {
 	err := &relaymodel.ErrorWithStatusCode{
 		StatusCode: http.StatusInternalServerError,

--- a/internal/relay/adaptor/openai/adaptor.go
+++ b/internal/relay/adaptor/openai/adaptor.go
@@ -459,7 +459,7 @@ func relayResponsesResponse(c *gin.Context, resp *http.Response) (*model.Usage, 
 	var bridgeEnvelope responsesBridgeEnvelope
 	_ = json.Unmarshal(responseBody, &bridgeEnvelope)
 	_ = json.Unmarshal(responseBody, &envelope)
-	rememberResponsesRouteFromBody(c, responseBody)
+	rememberResponsesRoutes(c, responseBody)
 	copyUpstreamResponseHeaders(c, resp.Header, false)
 	c.Writer.WriteHeader(resp.StatusCode)
 	if _, err := c.Writer.Write(responseBody); err != nil {

--- a/internal/relay/adaptor/openai/main.go
+++ b/internal/relay/adaptor/openai/main.go
@@ -155,7 +155,7 @@ func StreamResponsesHandler(c *gin.Context, resp *http.Response, modelName strin
 			continue
 		}
 
-		rememberResponsesRoute(c, extractResponsesStreamResponseID([]byte(data)))
+		rememberResponsesRoutes(c, []byte(data))
 
 		var envelope responsesStreamEnvelope
 		if err := json.Unmarshal([]byte(data), &envelope); err == nil {

--- a/internal/relay/adaptor/openai/responses_route.go
+++ b/internal/relay/adaptor/openai/responses_route.go
@@ -16,7 +16,20 @@ func rememberResponsesRoute(c *gin.Context, responseID string) {
 	responsestate.StoreRoute(responseID, c.GetString(ctxkey.ChannelId))
 }
 
+func rememberResponsesRoutes(c *gin.Context, raw []byte) {
+	if c == nil {
+		return
+	}
+	responsestate.StoreRoutes(responsestate.ExtractResponseItemIDs(raw), c.GetString(ctxkey.ChannelId))
+	responseID := responsestate.ExtractResponseID(raw)
+	if responseID == "" {
+		responseID = extractResponsesStreamResponseID(raw)
+	}
+	rememberResponsesRoute(c, responseID)
+}
+
 func rememberResponsesRouteFromBody(c *gin.Context, raw []byte) {
+	responsestate.StoreRoutes(responsestate.ExtractResponseItemIDs(raw), c.GetString(ctxkey.ChannelId))
 	rememberResponsesRoute(c, responsestate.ExtractResponseID(raw))
 }
 

--- a/internal/relay/responsestate/state.go
+++ b/internal/relay/responsestate/state.go
@@ -39,6 +39,7 @@ var (
 type RequestState struct {
 	PreviousResponseID string
 	HasToolOutput      bool
+	ItemIDs            []string
 }
 
 func AnalyzeRequestBody(raw []byte) RequestState {
@@ -53,6 +54,7 @@ func AnalyzeRequestBody(raw []byte) RequestState {
 	if root, ok := payload.(map[string]any); ok {
 		state.PreviousResponseID = strings.TrimSpace(asString(root["previous_response_id"]))
 	}
+	state.ItemIDs = extractInputItemIDs(payload)
 	state.HasToolOutput = containsFunctionCallOutput(payload)
 	return state
 }
@@ -71,6 +73,82 @@ func ExtractResponseID(raw []byte) string {
 		return ""
 	}
 	return strings.TrimSpace(asString(payload["id"]))
+}
+
+func ExtractResponseItemIDs(raw []byte) []string {
+	if len(raw) == 0 {
+		return nil
+	}
+	var payload any
+	if err := json.Unmarshal(raw, &payload); err != nil {
+		return nil
+	}
+	return extractResponseItemIDs(payload)
+}
+
+func extractInputItemIDs(value any) []string {
+	return extractIDsFromInput(value)
+}
+
+func extractIDsFromInput(value any) []string {
+	result := make([]string, 0)
+	var walk func(any)
+	walk = func(current any) {
+		switch typed := current.(type) {
+		case map[string]any:
+			if id := strings.TrimSpace(asString(typed["id"])); id != "" {
+				if itemType := strings.TrimSpace(asString(typed["type"])); itemType != "" && itemType != "response" {
+					result = appendUnique(result, id)
+				}
+			}
+			for key, child := range typed {
+				if key != "id" {
+					walk(child)
+				}
+			}
+		case []any:
+			for _, child := range typed {
+				walk(child)
+			}
+		}
+	}
+	walk(value)
+	return result
+}
+
+func extractResponseItemIDs(value any) []string {
+	result := make([]string, 0)
+	var walk func(any)
+	walk = func(current any) {
+		switch typed := current.(type) {
+		case map[string]any:
+			if id := strings.TrimSpace(asString(typed["id"])); id != "" {
+				if itemType := strings.TrimSpace(asString(typed["type"])); itemType != "" && itemType != "response" {
+					result = appendUnique(result, id)
+				}
+			}
+			for key, child := range typed {
+				if key != "id" {
+					walk(child)
+				}
+			}
+		case []any:
+			for _, child := range typed {
+				walk(child)
+			}
+		}
+	}
+	walk(value)
+	return result
+}
+
+func appendUnique(values []string, value string) []string {
+	for _, existing := range values {
+		if existing == value {
+			return values
+		}
+	}
+	return append(values, value)
 }
 
 func StoreRoute(responseID string, channelID string) {
@@ -98,6 +176,12 @@ func StoreRoute(responseID string, channelID string) {
 	}
 }
 
+func StoreRoutes(responseIDs []string, channelID string) {
+	for _, responseID := range responseIDs {
+		StoreRoute(responseID, channelID)
+	}
+}
+
 func LookupRoute(responseID string) (string, bool) {
 	normalizedResponseID := strings.TrimSpace(responseID)
 	if normalizedResponseID == "" {
@@ -118,6 +202,21 @@ func LookupRoute(responseID string) (string, bool) {
 		return channelID, true
 	}
 	return lookupMemoryRoute(normalizedResponseID)
+}
+
+func LookupRoutes(responseIDs []string) (string, bool, bool) {
+	selected := ""
+	for _, responseID := range responseIDs {
+		channelID, ok := LookupRoute(responseID)
+		if !ok {
+			continue
+		}
+		if selected != "" && selected != channelID {
+			return "", false, true
+		}
+		selected = channelID
+	}
+	return selected, selected != "", false
 }
 
 func lookupMemoryRoute(responseID string) (string, bool) {

--- a/internal/transport/http/middleware/auth.go
+++ b/internal/transport/http/middleware/auth.go
@@ -117,6 +117,9 @@ func hydrateResponsesRelayContext(c *gin.Context) {
 	if state.PreviousResponseID != "" {
 		c.Set(ctxkey.ResponsesPreviousResponseID, state.PreviousResponseID)
 	}
+	if len(state.ItemIDs) > 0 {
+		c.Set(ctxkey.ResponsesItemIDs, state.ItemIDs)
+	}
 	if state.PreviousResponseID != "" || state.HasToolOutput {
 		c.Set(ctxkey.ResponsesStatefulRequest, true)
 	}

--- a/internal/transport/http/middleware/distributor.go
+++ b/internal/transport/http/middleware/distributor.go
@@ -96,10 +96,19 @@ func recordRouteDecision(c *gin.Context, source string, groupID string, requestM
 
 func selectPinnedResponsesChannel(c *gin.Context, userGroup string, requestModel string, requestPath string) (*model.Channel, bool) {
 	previousResponseID := strings.TrimSpace(c.GetString(ctxkey.ResponsesPreviousResponseID))
-	if previousResponseID == "" {
+	itemIDs := responseItemIDsFromContext(c)
+	if previousResponseID == "" && len(itemIDs) == 0 {
 		return nil, false
 	}
-	channelID, ok := responsestate.LookupRoute(previousResponseID)
+	lookupIDs := append([]string{}, itemIDs...)
+	if previousResponseID != "" {
+		lookupIDs = append(lookupIDs, previousResponseID)
+	}
+	channelID, ok, conflict := responsestate.LookupRoutes(lookupIDs)
+	if conflict {
+		logger.RelayWarnf(c.Request.Context(), "DISTRIBUTE decision=state_conflict reason=responses_route_multiple_channels user_id=%s group=%s response_id=%s item_ids=%s endpoint=%s", c.GetString(ctxkey.Id), userGroup, previousResponseID, strings.Join(itemIDs, ","), requestPath)
+		return nil, true
+	}
 	if !ok {
 		logger.RelayInfof(c.Request.Context(), "DISTRIBUTE decision=miss reason=responses_route_missing user_id=%s group=%s response_id=%s endpoint=%s", c.GetString(ctxkey.Id), userGroup, previousResponseID, requestPath)
 		return nil, false
@@ -129,8 +138,23 @@ func selectPinnedResponsesChannel(c *gin.Context, userGroup string, requestModel
 	return channel, true
 }
 
+func responseItemIDsFromContext(c *gin.Context) []string {
+	value, exists := c.Get(ctxkey.ResponsesItemIDs)
+	if !exists {
+		return nil
+	}
+	ids, ok := value.([]string)
+	if !ok {
+		return nil
+	}
+	return ids
+}
+
 func selectEntitlementChannelForRequest(ctx context.Context, c *gin.Context, userID string, initialGroup string, initialSource *model.UserEntitlementSource, requestModel string) (*model.Channel, string, *model.UserEntitlementSource, error) {
 	requestPath := c.Request.URL.Path
+	if responseStateConflict(c) {
+		return nil, initialGroup, initialSource, fmt.Errorf("state_incompatible: 当前 Responses 会话同时绑定了多个上游渠道，请新建会话后重试")
+	}
 	if pinnedChannel, ok := selectPinnedResponsesChannel(c, initialGroup, requestModel, requestPath); ok {
 		return pinnedChannel, initialGroup, initialSource, nil
 	}
@@ -193,6 +217,21 @@ func selectEntitlementChannelForRequest(ctx context.Context, c *gin.Context, use
 	return nil, "", nil, fmt.Errorf("%s", message)
 }
 
+func responseStateConflict(c *gin.Context) bool {
+	if c == nil {
+		return false
+	}
+	ids := responseItemIDsFromContext(c)
+	if previous := strings.TrimSpace(c.GetString(ctxkey.ResponsesPreviousResponseID)); previous != "" {
+		ids = append(ids, previous)
+	}
+	if len(ids) == 0 {
+		return false
+	}
+	_, _, conflict := responsestate.LookupRoutes(ids)
+	return conflict
+}
+
 func Distribute() func(c *gin.Context) {
 	return func(c *gin.Context) {
 		ctx := c.Request.Context()
@@ -229,7 +268,15 @@ func Distribute() func(c *gin.Context) {
 			recordRouteDecision(c, "specific_channel", userGroup, requestModel, c.Request.URL.Path, []*model.Channel{channel}, nil, channel, "explicit")
 		} else {
 			if channel, userGroup, entitlementSource, err = selectEntitlementChannelForRequest(ctx, c, userId, userGroup, entitlementSource, requestModel); err != nil {
-				abortWithMessage(c, http.StatusServiceUnavailable, err.Error())
+				statusCode := http.StatusServiceUnavailable
+				message := err.Error()
+				if strings.HasPrefix(message, "state_incompatible: ") {
+					statusCode = http.StatusBadRequest
+					message = strings.TrimPrefix(message, "state_incompatible: ")
+					c.Set(ctxkey.RelayErrorType, "state_incompatible_error")
+					c.Set(ctxkey.RelayErrorCode, "state_incompatible")
+				}
+				abortWithMessage(c, statusCode, message)
 				return
 			}
 			c.Set(ctxkey.Group, userGroup)

--- a/internal/transport/http/middleware/utils.go
+++ b/internal/transport/http/middleware/utils.go
@@ -13,13 +13,22 @@ import (
 )
 
 func abortWithMessage(c *gin.Context, statusCode int, message string) {
+	errorType := c.GetString(ctxkey.RelayErrorType)
+	if errorType == "" {
+		errorType = "one_api_error"
+	}
+	errorCode := c.GetString(ctxkey.RelayErrorCode)
+	if errorCode == "" {
+		errorCode = "request_aborted"
+	}
 	c.Set(ctxkey.RelayError, strings.TrimSpace(message))
-	c.Set(ctxkey.RelayErrorType, "one_api_error")
-	c.Set(ctxkey.RelayErrorCode, "request_aborted")
+	c.Set(ctxkey.RelayErrorType, errorType)
+	c.Set(ctxkey.RelayErrorCode, errorCode)
 	c.JSON(statusCode, gin.H{
 		"error": gin.H{
 			"message": helper.MessageWithTraceID(message, c.GetString(helper.TraceIDKey)),
-			"type":    "one_api_error",
+			"type":    errorType,
+			"code":    errorCode,
 		},
 	})
 	c.Abort()


### PR DESCRIPTION
## Summary
- bind Responses response and item IDs to their originating channel
- reject cross-channel state conflicts with a non-retryable state_incompatible error
- document stateful Responses compatibility and operational guidance

## Tests
- go test ./internal/transport/http/middleware
- go test ./internal/relay/responsestate
- go test ./internal/relay/adaptor/openai
- go test ./internal/admin/controller