### PR TITLE
fix: clarify unavailable entitlement errors

### DIFF
--- a/internal/admin/model/user_entitlement_models.go
+++ b/internal/admin/model/user_entitlement_models.go
@@ -17,6 +17,18 @@ const (
 	UserEntitlementSourceRedemption = "redemption"
 )
 
+// EntitlementUnavailableError means the user cannot currently obtain a
+// group-backed entitlement for the requested model. The underlying source may
+// be an expired package or an exhausted balance lot, so callers must not claim
+// that the model is unconfigured.
+type EntitlementUnavailableError struct {
+	Model string
+}
+
+func (e *EntitlementUnavailableError) Error() string {
+	return fmt.Sprintf("当前账号对模型 %s 没有有效权益，可能是套餐已过期或额度已用尽，请充值或购买对应套餐后重试", e.Model)
+}
+
 type UserEntitlementSource struct {
 	SourceType string   `json:"source_type"`
 	SourceID   string   `json:"source_id,omitempty"`
@@ -460,7 +472,7 @@ func ResolveUserEntitlementGroupForModelWithDB(ctx context.Context, db *gorm.DB,
 	}
 	sources := payload.ByModel[normalizedModel]
 	if len(sources) == 0 {
-		return "", nil, fmt.Errorf("当前权益下对于模型 %s 无可用分组", normalizedModel)
+		return "", nil, &EntitlementUnavailableError{Model: normalizedModel}
 	}
 	source := sources[0]
 	return source.GroupID, &source, nil

--- a/internal/transport/http/middleware/distributor.go
+++ b/internal/transport/http/middleware/distributor.go
@@ -2,6 +2,7 @@ package middleware
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"math/rand"
 	"net/http"
@@ -239,8 +240,17 @@ func Distribute() func(c *gin.Context) {
 		requestModel := c.GetString(ctxkey.RequestModel)
 		userGroup, entitlementSource, groupErr := model.ResolveUserEntitlementGroupForModel(ctx, userId, requestModel)
 		if groupErr != nil {
-			logger.RelayWarnf(ctx, "DISTRIBUTE decision=abort reason=entitlement_group_missing user_id=%s model=%s endpoint=%s error=%q", userId, requestModel, c.Request.URL.Path, groupErr.Error())
-			abortWithMessage(c, http.StatusServiceUnavailable, groupErr.Error())
+			statusCode := http.StatusServiceUnavailable
+			errorCode := "request_aborted"
+			reason := "entitlement_resolution_failed"
+			if errors.As(groupErr, new(*model.EntitlementUnavailableError)) {
+				statusCode = http.StatusForbidden
+				errorCode = "entitlement_unavailable"
+				reason = "entitlement_unavailable"
+			}
+			c.Set(ctxkey.RelayErrorCode, errorCode)
+			logger.RelayWarnf(ctx, "DISTRIBUTE decision=abort reason=%s user_id=%s model=%s endpoint=%s status=%d error=%q", reason, userId, requestModel, c.Request.URL.Path, statusCode, groupErr.Error())
+			abortWithMessage(c, statusCode, groupErr.Error())
 			return
 		}
 		c.Set(ctxkey.Group, userGroup)


### PR DESCRIPTION
## Summary
- distinguish unavailable user entitlements from upstream failures
- return a clear balance/package guidance message for exhausted or expired entitlements
- use HTTP 403 with error code entitlement_unavailable for entitlement failures

## Tests
- go test ./internal/admin/model ./internal/transport/http/middleware